### PR TITLE
Update required python version to 3.8 instead of 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = ["numpy", "pyuff_ustb>=2.0.7", "scipy", "spekk>=1.0.6"]
 description = "vbeam: a fast and differentiable beamformer"
 name = "vbeam"
 readme = "README.md"
-requires-python = ">=3.9"
+
+requires-python = ">=3.8"
 version = "1.0.6"
 
 [project.urls]


### PR DESCRIPTION
3.8 works and is compatable with JAX for Windows.