### PR TITLE
Add probe object

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
   "pyuff_ustb>=2.0.7", 
   "scipy", 
   "spekk>=1.0.6",
-  "fastmath @ git+ssh://git@bitbucket.org/ntnuultrasoundgroup/fastmath.git",
+#  "fastmath @ git+ssh://git@bitbucket.org/ntnuultrasoundgroup/fastmath.git",
   ]
 description = "vbeam: a fast and differentiable beamformer"
 name = "vbeam"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,13 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
 ]
-dependencies = ["numpy", "pyuff_ustb>=2.0.7", "scipy", "spekk>=1.0.6"]
+dependencies = [
+  "numpy", 
+  "pyuff_ustb>=2.0.7", 
+  "scipy", 
+  "spekk>=1.0.6",
+  "fastmath @ git+ssh://git@bitbucket.org/ntnuultrasoundgroup/fastmath.git",
+  ]
 description = "vbeam: a fast and differentiable beamformer"
 name = "vbeam"
 readme = "README.md"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ numpy
 pyuff_ustb>=2.0.7
 scipy
 spekk>=1.0.6
+git+ssh://git@bitbucket.org/ntnuultrasoundgroup/fastmath.git

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,6 @@ setup(
         "pyuff_ustb>=2.0.7",
         "scipy",
         "spekk",
+        "fastmath @ git+ssh://git@bitbucket.org/ntnuultrasoundgroup/fastmath.git",
     ],
 )

--- a/tests/fastmath/test_traceable.py
+++ b/tests/fastmath/test_traceable.py
@@ -1,19 +1,19 @@
 from abc import ABC, abstractmethod
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import Backend, backend_manager
-from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 
 
 class MyABC(ABC):
     @abstractmethod
-    def do_thing(self):
-        ...
+    def do_thing(self): ...
 
 
 @traceable_dataclass(data_fields=["a"])
 class Item(MyABC):
-    a: np.ndarray = 1.0
+    a: ArrayOrNumber = 1.0
 
     def do_thing(self):
         return 2.0

--- a/vbeam/apodization/combine.py
+++ b/vbeam/apodization/combine.py
@@ -1,14 +1,16 @@
 from typing import Callable, Iterable, Optional
 
+from fastmath import ArrayOrNumber, field
+
 from vbeam.core import Apodization
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-@traceable_dataclass(("apodizations",), ("combiner",))
 class CombinedApodization(Apodization):
     apodizations: Iterable[Apodization]
-    combiner: Optional[Callable[[np.ndarray], float]] = None
+    combiner: Optional[Callable[[ArrayOrNumber], float]] = field(
+        default=None, static=True
+    )
 
     def __call__(self, *args, **kwargs) -> float:
         """Multiply the result of calling the Apodization objects."""
@@ -20,9 +22,9 @@ class CombinedApodization(Apodization):
 
 def combine_apodizations(
     *apodizations: Iterable[Apodization],
-    combiner: Optional[Callable[[np.ndarray], float]] = None,
+    combiner: Optional[Callable[[ArrayOrNumber], float]] = None,
 ) -> CombinedApodization:
     """Return a new Apodization object that combines all the given apodizations.
-    
+
     By default, apodizations are combined by taking the product of all their results."""
     return CombinedApodization(apodizations, combiner)

--- a/vbeam/apodization/combine.py
+++ b/vbeam/apodization/combine.py
@@ -14,7 +14,7 @@ class CombinedApodization(Apodization):
 
     def __call__(self, *args, **kwargs) -> float:
         """Multiply the result of calling the Apodization objects."""
-        values = np.array([apod(*args, **kwargs) for apod in self.apodizations])
+        values = np.stack([apod(*args, **kwargs) for apod in self.apodizations])
         if self.combiner is not None:
             return self.combiner(values)
         return np.prod(values)

--- a/vbeam/apodization/mla.py
+++ b/vbeam/apodization/mla.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from fastmath import ArrayOrNumber, Array
+from fastmath import Array, ArrayOrNumber
 
 from vbeam.core import Apodization, ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
@@ -26,7 +26,7 @@ class MLAApodization(Apodization):
         probe: ProbeGeometry,
         sender: Array,
         receiver: ArrayOrNumber,
-        sender: Array,
+        point_position: Array,
         wave_data: WaveData,
     ) -> float:
         # Geometry assumes 2D points

--- a/vbeam/apodization/mla.py
+++ b/vbeam/apodization/mla.py
@@ -1,14 +1,14 @@
 from typing import Tuple
 
+from fastmath import ArrayOrNumber
+
 from vbeam.core import Apodization, ElementGeometry, WaveData
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import Line
 
 from .window import Window
 
 
-@traceable_dataclass(("window", "beam_width", "array_bounds_x"))
 class MLAApodization(Apodization):
     """Perform multiple line acquisition (MLA) in cartesian space.
 
@@ -24,7 +24,7 @@ class MLAApodization(Apodization):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:

--- a/vbeam/apodization/mla.py
+++ b/vbeam/apodization/mla.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from vbeam.core import Apodization, ElementGeometry, WaveData
+from vbeam.core import Apodization, ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import Line
@@ -23,9 +23,10 @@ class MLAApodization(Apodization):
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
+        receiver: np.ndarray,
         point_position: np.ndarray,
-        receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:
         # Geometry assumes 2D points

--- a/vbeam/apodization/no_apodization.py
+++ b/vbeam/apodization/no_apodization.py
@@ -1,8 +1,6 @@
 from vbeam.core import Apodization
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-@traceable_dataclass()
 class NoApodization(Apodization):
     """Always return 1.0 (no weighting)."""
 

--- a/vbeam/apodization/plane_wave.py
+++ b/vbeam/apodization/plane_wave.py
@@ -1,23 +1,23 @@
 from typing import Optional, Tuple, Union
 
+from fastmath import ArrayOrNumber
+
 from vbeam.core import Apodization, ElementGeometry, WaveData
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util import ensure_2d_point
 from vbeam.util.geometry.v2 import Line, distance
 
 from .window import Window
 
 
-@traceable_dataclass(("array_bounds", "window"))
 class PlaneWaveTransmitApodization(Apodization):
-    array_bounds: Tuple[np.ndarray, np.ndarray]
+    array_bounds: Tuple[ArrayOrNumber, ArrayOrNumber]
     window: Optional[Window] = None
 
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:
@@ -65,7 +65,6 @@ class PlaneWaveTransmitApodization(Apodization):
         return apodization_value * 1.0
 
 
-@traceable_dataclass(("window", "f_number"))
 class PlaneWaveReceiveApodization(Apodization):
     window: Window
     f_number: Union[float, Tuple[float, float]]
@@ -73,7 +72,7 @@ class PlaneWaveReceiveApodization(Apodization):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:

--- a/vbeam/apodization/plotting.py
+++ b/vbeam/apodization/plotting.py
@@ -1,10 +1,10 @@
 from typing import Callable, Optional
 
+from fastmath import ArrayOrNumber
 from spekk import Spec
 
 from vbeam.apodization.util import get_apodization_values
 from vbeam.core import Apodization, ElementGeometry, WaveData
-from vbeam.fastmath import numpy as np
 from vbeam.util._default_values import (
     _default_point_position,
     _default_receiver,
@@ -16,11 +16,11 @@ from vbeam.util._default_values import (
 def plot_apodization(
     apodization: Apodization,
     sender: Optional[ElementGeometry] = None,
-    point_position: Optional[np.ndarray] = None,
+    point_position: Optional[ArrayOrNumber] = None,
     receiver: Optional[ElementGeometry] = None,
     wave_data: Optional[WaveData] = None,
     spec: Optional[Spec] = None,
-    postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+    postprocess: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
     average_overlap: bool = True,
     jit: bool = True,
     ax=None,  # : Optional[matplotlib.pyplot.Axes]

--- a/vbeam/apodization/plotting.py
+++ b/vbeam/apodization/plotting.py
@@ -3,21 +3,19 @@ from typing import Callable, Optional
 from spekk import Spec
 
 from vbeam.apodization.util import get_apodization_values
-from vbeam.core import Apodization, ElementGeometry, WaveData
+from vbeam.core import Apodization, ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.util._default_values import (
     _default_point_position,
-    _default_receiver,
-    _default_sender,
+    _default_probe,
     _default_wave_data,
 )
 
 
 def plot_apodization(
     apodization: Apodization,
-    sender: Optional[ElementGeometry] = None,
+    probe: Optional[ProbeGeometry] = None,
     point_position: Optional[np.ndarray] = None,
-    receiver: Optional[ElementGeometry] = None,
     wave_data: Optional[WaveData] = None,
     spec: Optional[Spec] = None,
     postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
@@ -32,21 +30,18 @@ def plot_apodization(
     conversion)."""
     # Try to set helpful default values
     spec = spec if spec is not None else Spec({})
-    if sender is None:
-        sender, spec = _default_sender(spec)
+    if probe is None:
+        probe, spec = _default_probe(spec)
     if point_position is None:
         point_position, spec = _default_point_position(spec)
-    if receiver is None:
-        receiver, spec = _default_receiver(spec)
     if wave_data is None:
         wave_data, spec = _default_wave_data(spec)
 
     # Calculate apodization values
     vals = get_apodization_values(
         apodization,
-        sender,
+        probe,
         point_position,
-        receiver,
         wave_data,
         spec,
         # We want to keep the dimensions of point_position

--- a/vbeam/apodization/rtb.py
+++ b/vbeam/apodization/rtb.py
@@ -1,18 +1,19 @@
 from typing import Optional, Tuple
 
+from fastmath import ArrayOrNumber, field
+
 from vbeam.apodization.window import Window
 from vbeam.core import Apodization, ElementGeometry, WaveData
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util import ensure_2d_point
 from vbeam.util.geometry.v2 import Line, distance
 
 
 def rtb_apodization(
-    point: np.ndarray,
-    array_left: np.ndarray,
-    array_right: np.ndarray,
-    focus_point: np.ndarray,
+    point: ArrayOrNumber,
+    array_left: ArrayOrNumber,
+    array_right: ArrayOrNumber,
+    focus_point: ArrayOrNumber,
     minimum_aperture: float,
     maximum_aperture: Optional[float] = None,
     window: Optional[Window] = None,
@@ -77,17 +78,13 @@ def rtb_apodization(
     return value
 
 
-@traceable_dataclass(
-    data_fields=("array_bounds", "array_width", "minimum_aperture", "window"),
-    aux_fields=("use_parent",),
-)
 class RTBApodization(Apodization):
-    array_bounds: Optional[Tuple[np.ndarray, np.ndarray]] = None
+    array_bounds: Optional[Tuple[ArrayOrNumber, ArrayOrNumber]] = None
     array_width: Optional[float] = None
     minimum_aperture: float = 0.001  # TODO: Calculate this based on F# and wavelength
     maximum_aperture: Optional[float] = None
     window: Optional[Window] = None
-    use_parent: bool = False
+    use_parent: bool = field(default=False, static=True)
 
     def __post_init__(self):
         if self.array_bounds is None and self.array_width is None:
@@ -96,7 +93,7 @@ class RTBApodization(Apodization):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:
@@ -118,7 +115,6 @@ class RTBApodization(Apodization):
         )
 
 
-@traceable_dataclass((("array_width", "minimum_aperture", "window", "use_parent")))
 class SteppingApertureRTBApodization(Apodization):
     array_width: float
     minimum_aperture: float = 0.001  # TODO: Calculate this based on F# and wavelength
@@ -128,7 +124,7 @@ class SteppingApertureRTBApodization(Apodization):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:

--- a/vbeam/apodization/rtb.py
+++ b/vbeam/apodization/rtb.py
@@ -1,12 +1,11 @@
 from typing import Optional, Tuple
 
 from vbeam.apodization.window import Window
-from vbeam.core import Apodization, ElementGeometry, WaveData
+from vbeam.core import Apodization, ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util import ensure_2d_point
 from vbeam.util.geometry.v2 import Line, distance
-
 
 def rtb_apodization(
     point: np.ndarray,
@@ -76,88 +75,65 @@ def rtb_apodization(
         value = np.minimum(value, window(distance_mid / maximum_aperture))
     return value
 
-
-@traceable_dataclass(
-    data_fields=("array_bounds", "array_width", "minimum_aperture", "window"),
-    aux_fields=("use_parent",),
-)
+@traceable_dataclass(("minimum_aperture", "maximum_aperture", "window","replacement_sender") )
 class RTBApodization(Apodization):
-    array_bounds: Optional[Tuple[np.ndarray, np.ndarray]] = None
-    array_width: Optional[float] = None
     minimum_aperture: float = 0.001  # TODO: Calculate this based on F# and wavelength
     maximum_aperture: Optional[float] = None
     window: Optional[Window] = None
-    use_parent: bool = False
-
-    def __post_init__(self):
-        if self.array_bounds is None and self.array_width is None:
-            raise ValueError("Either array bounds or array width must be set")
+    replacement_sender: Optional[np.ndarray] = None
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
+        receiver: np.ndarray,
         point_position: np.ndarray,
-        receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:
-        array_bounds = (
-            self.array_bounds
-            if self.array_bounds is not None
-            else get_bounds(
-                array_width=self.array_width, sender=sender, use_parent=self.use_parent
-            )
-        )
-        return rtb_apodization(
-            point_position,
-            array_bounds[0],
-            array_bounds[1],
-            wave_data.source,
-            self.minimum_aperture,
-            self.maximum_aperture,
-            self.window,
-        )
-
-
-@traceable_dataclass((("array_width", "minimum_aperture", "window", "use_parent")))
-class SteppingApertureRTBApodization(Apodization):
-    array_width: float
-    minimum_aperture: float = 0.001  # TODO: Calculate this based on F# and wavelength
-    window: Optional[Window] = None
-    use_parent: bool = False
-
-    def __call__(
-        self,
-        sender: ElementGeometry,
-        point_position: np.ndarray,
-        receiver: ElementGeometry,
-        wave_data: WaveData,
-    ) -> float:
-        sender_element_position = np.where(
-            self.use_parent, sender.parent_element.position, sender.position
-        )
-        sender_element_theta = np.where(
-            self.use_parent, sender.parent_element.theta, sender.theta
-        )
-        sender_normal = np.array(
-            [np.sin(sender_element_theta), 0.0, np.cos(sender_element_theta)]
-        )
-        array_left = (
-            sender_element_position
-            + np.cross(np.array([0, -1, 0]), sender_normal) * self.array_width / 2
-        )
-        array_right = (
-            sender_element_position
-            + np.cross(np.array([0, 1, 0]), sender_normal) * self.array_width / 2
-        )
+        if self.replacement_sender is None:
+            sender_element_position =  sender
+        else:
+            sender_element_position =  self.replacement_sender
+        array_left, array_right,array_up, array_down = probe.get_tx_aperture_borders(sender=sender_element_position)
         return rtb_apodization(
             point_position,
             array_left,
             array_right,
             wave_data.source,
             self.minimum_aperture,
+            self.maximum_aperture,
             self.window,
         )
 
+@traceable_dataclass(("minimum_aperture", "window","replacement_sender"))
+class SteppingApertureRTBApodization(Apodization):
+    minimum_aperture: float = 0.001  # TODO: Calculate this based on F# and wavelength
+    window: Optional[Window] = None
+    replacement_sender: np.ndarray = None
+
+    def __call__(
+        self,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
+        receiver: np.ndarray,
+        point_position: np.ndarray,
+        wave_data: WaveData,
+    ) -> float:
+        if self.replacement_sender is None:
+            sender_element_position =  sender
+        else:
+            sender_element_position =  self.replacement_sender
+        
+        array_left, array_right,array_up, array_down = probe.get_tx_aperture_borders(sender=sender_element_position)
+        return rtb_apodization(
+            point_position,
+            array_left,
+            array_right,
+            wave_data.source,
+            self.minimum_aperture,
+            self.maximum_aperture,
+            self.window,
+        )
 
 def get_bounds(
     array_width,

--- a/vbeam/apodization/tx_rx_apodization.py
+++ b/vbeam/apodization/tx_rx_apodization.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from vbeam.core import Apodization, ElementGeometry, WaveData
+from vbeam.core import Apodization, ElementGeometry, ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 
@@ -15,14 +15,15 @@ class TxRxApodization(Apodization):
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
+        receiver: np.ndarray,
         point_position: np.ndarray,
-        receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:
         weight = 1.0
         if self.transmit:
-            weight *= self.transmit(sender, point_position, receiver, wave_data)
+            weight *= self.transmit(probe, sender, receiver, point_position, wave_data)
         if self.receive:
-            weight *= self.receive(sender, point_position, receiver, wave_data)
+            weight *= self.receive(probe, sender,receiver, point_position, wave_data)
         return weight

--- a/vbeam/apodization/tx_rx_apodization.py
+++ b/vbeam/apodization/tx_rx_apodization.py
@@ -1,11 +1,10 @@
 from typing import Optional
 
+from fastmath import ArrayOrNumber
+
 from vbeam.core import Apodization, ElementGeometry, WaveData
-from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-@traceable_dataclass(("transmit", "receive"))
 class TxRxApodization(Apodization):
     """Apodization for both transmit and receive (just a container of two Apodization
     functions)."""
@@ -16,7 +15,7 @@ class TxRxApodization(Apodization):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:

--- a/vbeam/apodization/util.py
+++ b/vbeam/apodization/util.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence
 
 from spekk import Spec
 
-from vbeam.core import Apodization, ElementGeometry, WaveData
+from vbeam.core import Apodization, ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.util import _deprecations
 from vbeam.util.transformations import *
@@ -12,9 +12,10 @@ from vbeam.util.transformations import *
 @_deprecations.renamed_kwargs("1.0.5", average_overlap="average")
 def get_apodization_values(
     apodization: Apodization,
-    sender: ElementGeometry,
+    probe: ProbeGeometry,
+    sender: np.ndarray,
+    receiver: np.ndarray,
     point_position: np.ndarray,
-    receiver: ElementGeometry,
     wave_data: WaveData,
     spec: Spec,
     dimensions: Optional[Sequence[str]] = None,
@@ -23,7 +24,7 @@ def get_apodization_values(
 ):
     """
     Calculate and return the apodization values based on the provided arguments
-    (``sender``, ``point_position``, ``receiver``, and ``wave_data``).
+    (``probe``, ``sender``, ``point_position``, ``receiver``, and ``wave_data``).
 
     The ``dimensions`` argument determines what dimensions to keep; all others are
     summed over (except when ``dimesions`` is None where we keep all dimensions
@@ -33,9 +34,9 @@ def get_apodization_values(
 
     Args:
         apodization (Apodization): The apodization function to use.
-        sender (ElementGeometry): The sender argument to ``apodization``.
+        sender (np.ndarray): The sender argument to ``apodization``.
         point_position (np.ndarray): The point_position argument to ``apodization``.
-        receiver (ElementGeometry): The receiver argument to ``apodization``.
+        receiver (np.ndarray): The receiver argument to ``apodization``.
         wave_data (WaveData): The wave data argument to ``apodization``.
         spec (Spec): A spec describing the dimensions/shape of the arguments.
         dimensions (Optional[Sequence[str]]): The dimensions to keep in the returned
@@ -50,9 +51,10 @@ def get_apodization_values(
     """
     kwargs = {
         "apodization": apodization,
+        "probe": probe,
         "sender": sender,
-        "point_position": point_position,
         "receiver": receiver,
+        "point_position": point_position,
         "wave_data": wave_data,
     }
 
@@ -64,9 +66,8 @@ def get_apodization_values(
     # Define what dimensions to vmap and sum over and how
     vmap_dimensions = (
         spec["apodization"].dimensions
-        | spec["sender"].dimensions
-        | spec["point_position"].dimensions
         | spec["receiver"].dimensions
+        | spec["point_position"].dimensions
         | spec["wave_data"].dimensions
     )
     sum_dimensions = vmap_dimensions - set(dimensions)

--- a/vbeam/apodization/util.py
+++ b/vbeam/apodization/util.py
@@ -1,7 +1,7 @@
 import math
 from typing import Optional, Sequence
 
-from fastmath import ArrayOrNumber, Array
+from fastmath import Array
 from spekk import Spec
 
 from vbeam.core import Apodization, ProbeGeometry, WaveData
@@ -16,7 +16,7 @@ def get_apodization_values(
     probe: ProbeGeometry,
     sender: Array,
     receiver: Array,
-    sender: Array,
+    point_position: Array,
     wave_data: WaveData,
     spec: Spec,
     dimensions: Optional[Sequence[str]] = None,

--- a/vbeam/apodization/util.py
+++ b/vbeam/apodization/util.py
@@ -1,6 +1,7 @@
 import math
 from typing import Optional, Sequence
 
+from fastmath import ArrayOrNumber
 from spekk import Spec
 
 from vbeam.core import Apodization, ElementGeometry, WaveData
@@ -13,7 +14,7 @@ from vbeam.util.transformations import *
 def get_apodization_values(
     apodization: Apodization,
     sender: ElementGeometry,
-    point_position: np.ndarray,
+    point_position: ArrayOrNumber,
     receiver: ElementGeometry,
     wave_data: WaveData,
     spec: Spec,
@@ -34,7 +35,7 @@ def get_apodization_values(
     Args:
         apodization (Apodization): The apodization function to use.
         sender (ElementGeometry): The sender argument to ``apodization``.
-        point_position (np.ndarray): The point_position argument to ``apodization``.
+        point_position (ArrayOrNumber): The point_position argument to ``apodization``.
         receiver (ElementGeometry): The receiver argument to ``apodization``.
         wave_data (WaveData): The wave data argument to ``apodization``.
         spec (Spec): A spec describing the dimensions/shape of the arguments.
@@ -45,7 +46,7 @@ def get_apodization_values(
         jit (bool): If True, the process is JIT-compiled (if the backend supports it).
 
     Returns:
-        np.ndarray: The calculated apodization values with shape corresponding to the
+        ArrayOrNumber: The calculated apodization values with shape corresponding to the
         dimensions defined in ``dimensions``.
     """
     kwargs = {

--- a/vbeam/apodization/window.py
+++ b/vbeam/apodization/window.py
@@ -4,13 +4,14 @@ functions or tapering functions).
 See the notebook ``docs/tutorials/apodization/windows.ipynb`` for a visualization of 
 the various implemented windows."""
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
+
+from fastmath import Module
 
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-class Window(ABC):
+class Window(Module):
     """A window (also called apodization function or tapering function) is used to get
     more desirable main-lobe/side-lobe characteristics. A Window object can be called
     as afunction. It takes a number between 0 and 0.5 and returns the weight of the
@@ -30,7 +31,6 @@ class Window(ABC):
         and it tapers off as the ratio approaches 0.5."""
 
 
-@traceable_dataclass()
 class NoWindow(Window):
     def __call__(self, ratio: float) -> float:
         return np.ones(ratio.shape)
@@ -40,13 +40,11 @@ def _within_valid(ratio: float) -> bool:
     return np.logical_and(0 <= ratio, ratio <= 0.5)
 
 
-@traceable_dataclass()
 class Rectangular(Window):
     def __call__(self, ratio: float) -> float:
         return _within_valid(ratio) * 1.0
 
 
-@traceable_dataclass(("a0", "a1"))
 class Hanning(Window):
     a0: float = 0.5
     a1: float = 0.5
@@ -55,13 +53,11 @@ class Hanning(Window):
         return _within_valid(ratio) * (self.a0 + self.a1 * np.cos(2 * np.pi * ratio))
 
 
-@traceable_dataclass()
 class Hamming(Window):
     def __call__(self, ratio: float) -> float:
         return Hanning(0.53836, 0.46164)(ratio)
 
 
-@traceable_dataclass(("roll",))
 class Tukey(Window):
     roll: float
 
@@ -89,7 +85,6 @@ def Tukey80() -> Tukey:
     return Tukey(0.8)
 
 
-@traceable_dataclass()
 class Bartlett(Window):
     def __call__(self, ratio: float) -> float:
         return _within_valid(ratio) * (0.5 - ratio) * 2

--- a/vbeam/core/__init__.py
+++ b/vbeam/core/__init__.py
@@ -66,6 +66,7 @@ single :term:`receiving element<Receiver>`, a single
 
 from vbeam.core.apodization import Apodization
 from vbeam.core.element_geometry import ElementGeometry
+from vbeam.core.probe_geometry import ProbeGeometry
 from vbeam.core.interpolation import InterpolationSpace1D
 from vbeam.core.kernels import KernelData, SignalForPointData, signal_for_point
 from vbeam.core.speed_of_sound import SpeedOfSound
@@ -79,6 +80,7 @@ from vbeam.core.wavefront import (
 __all__ = [
     "Apodization",
     "ElementGeometry",
+    "ProbeGeometry",
     "InterpolationSpace1D",
     "KernelData",
     "SignalForPointData",

--- a/vbeam/core/apodization.py
+++ b/vbeam/core/apodization.py
@@ -2,7 +2,7 @@
 
 from abc import abstractmethod
 
-from fastmath import Array, ArrayOrNumber, Module
+from fastmath import Array, Module
 
 from vbeam.core.probe_geometry import ProbeGeometry
 from vbeam.core.wave_data import WaveData
@@ -15,7 +15,7 @@ class Apodization(Module):
         probe: ProbeGeometry,
         sender: Array,
         receiver: Array,
-        sender: Array,
+        point_position: Array,
         wave_data: WaveData,
     ) -> float:
         """

--- a/vbeam/core/apodization.py
+++ b/vbeam/core/apodization.py
@@ -1,19 +1,19 @@
 "Point-based apodization for weighting the delayed signal."
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
-from vbeam.fastmath import numpy as np
+from fastmath import ArrayOrNumber, Module
 
-from .element_geometry import ElementGeometry
-from .wave_data import WaveData
+from vbeam.core.element_geometry import ElementGeometry
+from vbeam.core.wave_data import WaveData
 
 
-class Apodization(ABC):
+class Apodization(Module):
     @abstractmethod
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:

--- a/vbeam/core/apodization.py
+++ b/vbeam/core/apodization.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from vbeam.fastmath import numpy as np
 
 from .element_geometry import ElementGeometry
+from .probe_geometry import ProbeGeometry
 from .wave_data import WaveData
 
 
@@ -12,9 +13,10 @@ class Apodization(ABC):
     @abstractmethod
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
+        receiver: np.ndarray,
         point_position: np.ndarray,
-        receiver: ElementGeometry,
         wave_data: WaveData,
     ) -> float:
         """

--- a/vbeam/core/interpolation.py
+++ b/vbeam/core/interpolation.py
@@ -1,15 +1,15 @@
 "Interface for interpolating the :term:`signal` given a delay."
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
-from vbeam.fastmath import numpy as np
+from fastmath import ArrayOrNumber, Module
 
 
-class InterpolationSpace1D(ABC):
+class InterpolationSpace1D(Module):
     """An interface for interpolating data in 1D."""
 
     @abstractmethod
-    def __call__(self, x: np.ndarray, fp: np.ndarray) -> np.ndarray:
+    def __call__(self, x: ArrayOrNumber, fp: ArrayOrNumber) -> ArrayOrNumber:
         """Evaluate the points x on the discrete array fp.
 
         Any point in x that is outside of the range of fp is evaluated as zero."""
@@ -17,10 +17,8 @@ class InterpolationSpace1D(ABC):
 
     @property
     @abstractmethod
-    def start(self) -> float:
-        ...
+    def start(self) -> float: ...
 
     @property
     @abstractmethod
-    def end(self) -> float:
-        ...
+    def end(self) -> float: ...

--- a/vbeam/core/kernels.py
+++ b/vbeam/core/kernels.py
@@ -9,6 +9,8 @@ See also:
 from dataclasses import dataclass
 from typing import Optional, Tuple, Union
 
+from fastmath import ArrayOrNumber
+
 from vbeam.core.apodization import Apodization
 from vbeam.core.element_geometry import ElementGeometry
 from vbeam.core.interpolation import InterpolationSpace1D
@@ -25,9 +27,9 @@ from vbeam.fastmath import numpy as np
 
 def signal_for_point(
     sender: ElementGeometry,
-    point_position: np.ndarray,
+    point_position: ArrayOrNumber,
     receiver: ElementGeometry,
-    signal: np.ndarray,
+    signal: ArrayOrNumber,
     transmitted_wavefront: TransmittedWavefront,
     reflected_wavefront: ReflectedWavefront,
     speed_of_sound: Union[float, SpeedOfSound],
@@ -35,7 +37,7 @@ def signal_for_point(
     interpolate: InterpolationSpace1D,
     modulation_frequency: Optional[float],
     apodization: Apodization,
-) -> np.ndarray:
+) -> ArrayOrNumber:
     """The core beamforming function. Return the delayed and interpolated signal from a
     single transmit, for a single receiver, for a single point (pixel).
 
@@ -104,9 +106,9 @@ class SignalForPointData(KernelData):
     See the docstring of signal_for_point for documentation of each field."""
 
     sender: ElementGeometry
-    point_position: np.ndarray
+    point_position: ArrayOrNumber
     receiver: ElementGeometry
-    signal: np.ndarray
+    signal: ArrayOrNumber
     transmitted_wavefront: TransmittedWavefront
     reflected_wavefront: ReflectedWavefront
     speed_of_sound: Union[float, SpeedOfSound]

--- a/vbeam/core/probe_geometry.py
+++ b/vbeam/core/probe_geometry.py
@@ -12,8 +12,8 @@ identity_fn = lambda x: x  # Just return value as-is
 
 @traceable_dataclass(("ROC", "rx_aperture_length_s", "tx_aperture_length_s"))
 class ProbeGeometry:
-    """A container for probe parameters geometries.
-
+    """A container for probe parameters.
+    The aperture lengths are arc lenghts of the probe surface in azimuth and elevation. 
     """
     ROC: tuple[float, float] # (azimuth, elevation)
     rx_aperture_length_s: tuple[float, float] = None # (width, height)
@@ -29,7 +29,6 @@ class ProbeGeometry:
             _maybe_getitem(self.tx_aperture_length_s),
         )
 
-    
     @property
     def curvature_center(self):
         return (np.array([0.0,0.0,-self.ROC[0]]), np.array([0.0,0.0,-self.ROC[1]]) ) 
@@ -75,12 +74,6 @@ class ProbeGeometry:
         down = self.surface2cart((0.0, -self.tx_aperture_length_s[1]/2))
         up = self.surface2cart((0.0, self.tx_aperture_length_s[1]/2))
         return (left, right, up, down)
-        return [
-                np.array([self.ROC[0]*np.sin(self.rx_aperture_length_s[0]/2/self.ROC[0]),0.0,self.ROC[0]-self.ROC[0]*np.cos(self.rx_aperture_length_s[0]/2/self.ROC[0])]),
-                np.array([-self.ROC[0]*np.sin(self.rx_aperture_length_s[0]/2/self.ROC[0]),0.0,self.ROC[0]-self.ROC[0]*np.cos(self.rx_aperture_length_s[0]/2/self.ROC[0])]),
-                np.array([0.0,self.ROC[1]*np.sin(self.rx_aperture_length_s[1]/2/self.ROC[1]),self.ROC[1]-self.ROC[1]*np.cos(self.rx_aperture_length_s[1]/2/self.ROC[1])]),
-                np.array([0.0,-self.ROC[1]*np.sin(self.rx_aperture_length_s[1]/2/self.ROC[1]),self.ROC-self.ROC[1]*np.cos(self.rx_aperture_length_s[1]/2/self.ROC[1])])
-        ]
 
     def get_tx_aperture_borders(self, sender):
         left = self.surface2cart((self.cart2surface(position=sender)[0] - self.tx_aperture_length_s[0]/2,0.0))

--- a/vbeam/core/probe_geometry.py
+++ b/vbeam/core/probe_geometry.py
@@ -33,12 +33,10 @@ class ProbeGeometry:
     def curvature_center(self):
         return (np.array([0.0,0.0,-self.ROC[0]]), np.array([0.0,0.0,-self.ROC[1]]) ) 
     
-    @property
     def get_sender_normal(self):
         vector = self.sender_position - self.curvature_center
         return vector / distance(vector)
     
-    @property
     def get_receiver_normal(self):
         vector = self.receiver_position - self.curvature_center
         return vector / distance(vector)
@@ -49,17 +47,13 @@ class ProbeGeometry:
     def get_phi(self,position):
         return np.arctan2(position[1],self.ROC[1]+position[2])
     
-    def get_surface_length(self, position):
-        theta = self.get_theta(position=position)
-        phi = self.get_phi(position=position)
-        return (self.ROC*theta, self.ROC*phi)
 
     def aperture_distance(self,position1, position2):
         if position2 is None:
             return np.sqrt(self.get_surface_length(position=position1)[0]**2 + self.get_surface_length(position=position1)[1]**2)
         else:
-            pos1_s = self.get_surface_length(position=position1)
-            pos2_s = self.get_surface_length(position=position2)
+            pos1_s = self.cart2surface(position=position1)
+            pos2_s = self.cart2surface(position=position2)
             return (np.sqrt( (pos1_s[0]-pos2_s[0])**2 + (pos1_s[1]-pos2_s[1])**2 ))
 
     def cart2surface(self, position):
@@ -75,12 +69,11 @@ class ProbeGeometry:
                         )
         ))
     
-    @property
     def get_rx_aperture_borders(self):
         left = self.surface2cart((-self.rx_aperture_length_s[0]/2,0.0))
-        right = self.surface2cart((self.tx_aperture_length_s[0]/2,0.0))
-        down = self.surface2cart((0.0, -self.tx_aperture_length_s[1]/2))
-        up = self.surface2cart((0.0, self.tx_aperture_length_s[1]/2))
+        right = self.surface2cart((self.rx_aperture_length_s[0]/2,0.0))
+        down = self.surface2cart((0.0, -self.rx_aperture_length_s[1]/2))
+        up = self.surface2cart((0.0, self.rx_aperture_length_s[1]/2))
         return (left, right, up, down)
 
     def get_tx_aperture_borders(self, sender):

--- a/vbeam/core/probe_geometry.py
+++ b/vbeam/core/probe_geometry.py
@@ -49,12 +49,12 @@ class ProbeGeometry:
     
 
     def aperture_distance(self,position1, position2):
+        pos1_s = self.cart2surface(position=position1)
         if position2 is None:
-            return np.sqrt(self.get_surface_length(position=position1)[0]**2 + self.get_surface_length(position=position1)[1]**2)
+            pos2_s = (0.0, 0.0)
         else:
-            pos1_s = self.cart2surface(position=position1)
             pos2_s = self.cart2surface(position=position2)
-            return (np.sqrt( (pos1_s[0]-pos2_s[0])**2 + (pos1_s[1]-pos2_s[1])**2 ))
+        return (np.sqrt( (pos1_s[0]-pos2_s[0])**2 + (pos1_s[1]-pos2_s[1])**2 ))
 
     def cart2surface(self, position):
         return (self.ROC[0]*self.get_theta(position=position), self.ROC[1]*self.get_phi(position=position))
@@ -64,8 +64,8 @@ class ProbeGeometry:
             self.ROC[0]*np.sin(position_s[0]/self.ROC[0]),
             self.ROC[1]*np.sin(position_s[1]/self.ROC[1]),
             np.where(self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0])>self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1]),
-                        self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0]),
-                        self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1])
+                        self.ROC[0]*np.cos(position_s[0]/self.ROC[0])-self.ROC[0],
+                        self.ROC[1]*np.cos(position_s[1]/self.ROC[1])-self.ROC[1]
                         )
         ))
     

--- a/vbeam/core/probe_geometry.py
+++ b/vbeam/core/probe_geometry.py
@@ -53,7 +53,15 @@ class ProbeGeometry:
         theta = self.get_theta(position=position)
         phi = self.get_phi(position=position)
         return (self.ROC*theta, self.ROC*phi)
-    
+
+    def aperture_distance(self,position1, position2):
+        if position2 is None:
+            return np.sqrt(self.get_surface_length(position=position1)[0]**2 + self.get_surface_length(position=position1)[1]**2)
+        else:
+            pos1_s = self.get_surface_length(position=position1)
+            pos2_s = self.get_surface_length(position=position2)
+            return (np.sqrt( (pos1_s[0]-pos2_s[0])**2 + (pos1_s[1]-pos2_s[1])**2 ))
+
     def cart2surface(self, position):
         return (self.ROC[0]*self.get_theta(position=position), self.ROC[1]*self.get_phi(position=position))
     
@@ -62,9 +70,9 @@ class ProbeGeometry:
             self.ROC[0]*np.sin(position_s[0]/self.ROC[0]),
             self.ROC[1]*np.sin(position_s[1]/self.ROC[1]),
             np.where(self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0])>self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1]),
-                     self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0]),
-                     self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1])
-                     )
+                        self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0]),
+                        self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1])
+                        )
         ))
     
     @property

--- a/vbeam/core/probe_geometry.py
+++ b/vbeam/core/probe_geometry.py
@@ -1,0 +1,116 @@
+"""A datastructure for representing a transducer probe excluding 
+the position, orientation, etc.
+"""
+
+from typing import Callable, Optional
+from vbeam.fastmath import numpy as np
+from vbeam.fastmath.traceable import traceable_dataclass
+from vbeam.util.geometry.v2 import distance
+
+identity_fn = lambda x: x  # Just return value as-is
+
+
+@traceable_dataclass(("ROC", "rx_aperture_length_s", "tx_aperture_length_s"))
+class ProbeGeometry:
+    """A container for probe parameters geometries.
+
+    """
+    ROC: tuple[float, float] # (azimuth, elevation)
+    rx_aperture_length_s: tuple[float, float] = None # (width, height)
+    tx_aperture_length_s: tuple[float, float] = None # (width, height)
+    def __postinit__(self):           
+        if type(self.ROC) is not tuple or len(self.ROC) != 2:
+            self.ROC = (self.ROC, self.ROC)
+    def __getitem__(self, *args) -> "ProbeGeometry":
+        _maybe_getitem = lambda attr: attr.__getitem__(*args) if attr is not None else None
+        return self.ProbeGeometry(
+            _maybe_getitem(self.ROC),
+            _maybe_getitem(self.rx_aperture_length_s),
+            _maybe_getitem(self.tx_aperture_length_s),
+        )
+
+    
+    @property
+    def curvature_center(self):
+        return (np.array([0.0,0.0,-self.ROC[0]]), np.array([0.0,0.0,-self.ROC[1]]) ) 
+    
+    @property
+    def get_sender_normal(self):
+        vector = self.sender_position - self.curvature_center
+        return vector / distance(vector)
+    
+    @property
+    def get_receiver_normal(self):
+        vector = self.receiver_position - self.curvature_center
+        return vector / distance(vector)
+    
+    def get_theta(self,position):
+        return np.arctan2(position[0],self.ROC[0]+position[2])
+    
+    def get_phi(self,position):
+        return np.arctan2(position[1],self.ROC[1]+position[2])
+    
+    def get_surface_length(self, position):
+        theta = self.get_theta(position=position)
+        phi = self.get_phi(position=position)
+        return (self.ROC*theta, self.ROC*phi)
+    
+    def cart2surface(self, position):
+        return (self.ROC[0]*self.get_theta(position=position), self.ROC[1]*self.get_phi(position=position))
+    
+    def surface2cart(self,position_s):
+        return np.array((
+            self.ROC[0]*np.sin(position_s[0]/self.ROC[0]),
+            self.ROC[1]*np.sin(position_s[1]/self.ROC[1]),
+            np.where(self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0])>self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1]),
+                     self.ROC[0]-self.ROC[0]*np.cos(position_s[0]/self.ROC[0]),
+                     self.ROC[1]-self.ROC[1]*np.cos(position_s[1]/self.ROC[1])
+                     )
+        ))
+    
+    @property
+    def get_rx_aperture_borders(self):
+        left = self.surface2cart((-self.rx_aperture_length_s[0]/2,0.0))
+        right = self.surface2cart((self.tx_aperture_length_s[0]/2,0.0))
+        down = self.surface2cart((0.0, -self.tx_aperture_length_s[1]/2))
+        up = self.surface2cart((0.0, self.tx_aperture_length_s[1]/2))
+        return (left, right, up, down)
+        return [
+                np.array([self.ROC[0]*np.sin(self.rx_aperture_length_s[0]/2/self.ROC[0]),0.0,self.ROC[0]-self.ROC[0]*np.cos(self.rx_aperture_length_s[0]/2/self.ROC[0])]),
+                np.array([-self.ROC[0]*np.sin(self.rx_aperture_length_s[0]/2/self.ROC[0]),0.0,self.ROC[0]-self.ROC[0]*np.cos(self.rx_aperture_length_s[0]/2/self.ROC[0])]),
+                np.array([0.0,self.ROC[1]*np.sin(self.rx_aperture_length_s[1]/2/self.ROC[1]),self.ROC[1]-self.ROC[1]*np.cos(self.rx_aperture_length_s[1]/2/self.ROC[1])]),
+                np.array([0.0,-self.ROC[1]*np.sin(self.rx_aperture_length_s[1]/2/self.ROC[1]),self.ROC-self.ROC[1]*np.cos(self.rx_aperture_length_s[1]/2/self.ROC[1])])
+        ]
+
+    def get_tx_aperture_borders(self, sender):
+        left = self.surface2cart((self.cart2surface(position=sender)[0] - self.tx_aperture_length_s[0]/2,0.0))
+        right = self.surface2cart((self.cart2surface(position=sender)[0] + self.tx_aperture_length_s[0]/2,0.0))
+        down = self.surface2cart((0.0, self.cart2surface(position=sender)[1] - self.tx_aperture_length_s[1]/2))
+        up = self.surface2cart((0.0, self.cart2surface(position=sender)[1] + self.tx_aperture_length_s[1]/2))
+        return (left, right, up, down)
+    
+    def set_rx_aperture_length(self,min_x,max_x, min_y, max_y):
+        width_s = np.arcsin(max_x/self.ROC[0])*self.ROC[0]-np.arcsin(min_x/self.ROC[0])*self.ROC[0]
+        height_s = np.arcsin(max_y/self.ROC[1])*self.ROC[1]-np.arcsin(min_y/self.ROC[1])*self.ROC[1]
+        self.rx_aperture_length_s = (width_s, height_s)
+
+    def set_tx_aperture_length(self,min_x,max_x, min_y, max_y):
+        width_s = np.arcsin(max_x/self.ROC[0])*self.ROC[0]-np.arcsin(min_x/self.ROC[0])*self.ROC[0]
+        height_s = np.arcsin(max_y/self.ROC[1])*self.ROC[1]-np.arcsin(min_y/self.ROC[1])*self.ROC[1]
+        self.tx_aperture_length_s = (width_s, height_s)
+
+    def with_updates_to(
+        self,
+        *,
+        ROC: Callable[[float], float] = identity_fn,
+        rx_aperture_length_s: Callable[tuple[float,float],float] = identity_fn,
+        tx_aperture_length_s: Callable[tuple[float,float],float] = identity_fn,
+    ) -> "ProbeGeometry":
+        return ProbeGeometry(
+            ROC=ROC(self.ROC) if callable(ROC) else ROC,
+            rx_aperture_length_s=rx_aperture_length_s(self.rx_aperture_length_s) if callable(rx_aperture_length_s) else rx_aperture_length_s,
+            tx_aperture_length_s=tx_aperture_length_s(self.tx_aperture_length_s) if callable(tx_aperture_length_s) else tx_aperture_length_s,
+        )
+
+    def copy(self) -> "ProbeGeometry":
+        return self.with_updates_to()

--- a/vbeam/core/speed_of_sound.py
+++ b/vbeam/core/speed_of_sound.py
@@ -1,18 +1,18 @@
 """Interface for sampling the speed of sound on a line, typically the line between a 
 :term:`sender` and a :term:`point`, and a :term:`point` and a :term:`receiver`. """
 
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
-from vbeam.fastmath import numpy as np
+from fastmath import ArrayOrNumber, Module
 
 
-class SpeedOfSound(ABC):
+class SpeedOfSound(Module):
     @abstractmethod
     def average(
         self,
-        sender_position: np.ndarray,
-        point_position: np.ndarray,
-        receiver_position: np.ndarray,
+        sender_position: ArrayOrNumber,
+        point_position: ArrayOrNumber,
+        receiver_position: ArrayOrNumber,
     ) -> float:
         """Sample the speed of sound between the sender, the point position, and the
         receiver, and return the average.

--- a/vbeam/core/wave_data.py
+++ b/vbeam/core/wave_data.py
@@ -11,14 +11,12 @@ focal point of the transmitted wave. A transmitted wave is usually one of three 
 
 from typing import Callable, Optional
 
-from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
+from fastmath import ArrayOrNumber, Module
 
 identity_fn = lambda x: x  # Just return value as-is
 
 
-@traceable_dataclass(("source", "azimuth", "elevation", "t0"))
-class WaveData:
+class WaveData(Module):
     """A vectorizable container of wave data: anything that is specific to a single
     transmitted wave. See this class' fields for what that could be.
 
@@ -30,7 +28,7 @@ class WaveData:
     64 transmitted waves in the dataset (each with x, y, and z source coordinates)."""
 
     # The location (x, y, z) of the virtual source for the transmitted wave
-    source: Optional[np.ndarray] = None
+    source: Optional[ArrayOrNumber] = None
     azimuth: Optional[float] = None
     elevation: Optional[float] = None
     # The time at which the transmitted wave passed through the "sender" element
@@ -46,8 +44,8 @@ class WaveData:
         >>> wave_data[1]
         WaveData(source=array([1, 1, 1]), azimuth=1, elevation=None, t0=None)
         """
-        _maybe_getitem = (
-            lambda attr: attr.__getitem__(*args) if attr is not None else None
+        _maybe_getitem = lambda attr: (
+            attr.__getitem__(*args) if attr is not None else None
         )
         return WaveData(
             _maybe_getitem(self.source),
@@ -74,7 +72,7 @@ class WaveData:
     def with_updates_to(
         self,
         *,
-        source: Callable[[np.ndarray], np.ndarray] = identity_fn,
+        source: Callable[[ArrayOrNumber], ArrayOrNumber] = identity_fn,
         azimuth: Callable[[float], float] = identity_fn,
         elevation: Callable[[float], float] = identity_fn,
         t0: Callable[[float], float] = identity_fn,

--- a/vbeam/core/wavefront.py
+++ b/vbeam/core/wavefront.py
@@ -5,19 +5,19 @@
 Wavefront models return a distance in meters. This way they are decoupled from the 
 speed of sound of the medium."""
 
-from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from abc import abstractmethod
 from typing import Callable, Union
 
+from fastmath import ArrayOrNumber, Module
+
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import distance
 
 from .element_geometry import ElementGeometry
 from .wave_data import WaveData
 
 
-class TransmittedWavefront(ABC):
+class TransmittedWavefront(Module):
     """The base class for defining wavefront models of transmitted waves.
 
     :class:`TransmittedWavefront` models are used to calculate the *distance (in
@@ -62,7 +62,7 @@ class TransmittedWavefront(ABC):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         wave_data: WaveData,
     ) -> Union[float, "MultipleTransmitDistances"]:
         """Return the *distance (in meters)* from the sender element to the point for a transmit.
@@ -76,8 +76,7 @@ class TransmittedWavefront(ABC):
         """
 
 
-@traceable_dataclass()
-class ReflectedWavefront:
+class ReflectedWavefront(Module):
     """The base class for defining wavefront models of reflected/backscattered waves.
 
     This is usually just the euclidian distance as there are limits to what we can
@@ -87,12 +86,13 @@ class ReflectedWavefront:
         :class:`TransmittedWavefront`
         :func:`~vbeam.core.kernels.signal_for_point`"""
 
-    def __call__(self, point_position: np.ndarray, receiver: ElementGeometry) -> float:
+    def __call__(
+        self, point_position: ArrayOrNumber, receiver: ElementGeometry
+    ) -> float:
         return distance(point_position, receiver.position)
 
 
-@dataclass
-class MultipleTransmitDistances:
+class MultipleTransmitDistances(Module):
     """Multiple distance values returned from a :class:`TransmittedWavefront`.
 
     Some more advanced :class:`TransmittedWavefront` models may return multiple
@@ -108,8 +108,8 @@ class MultipleTransmitDistances:
     will apply them to the :attr:`values` attribute as if it was just a numpy array.
 
     Attributes:
-        values (np.ndarray): The distance values that will be used to delay the element signals.
-        aggregate_samples (Callable[[np.ndarray, np.ndarray], np.ndarray]): A function
+        values (ArrayOrNumber): The distance values that will be used to delay the element signals.
+        aggregate_samples (Callable[[ArrayOrNumber, ArrayOrNumber], ArrayOrNumber]): A function
             that will be used to combine the delayed samples into one value, for
             example as a weighted sum. If None, the samples will be averaged.
 
@@ -118,8 +118,8 @@ class MultipleTransmitDistances:
         :class:`TransmittedWavefront`
     """
 
-    values: np.ndarray
-    aggregate_samples: Callable[[np.ndarray, np.ndarray], np.ndarray] = None
+    values: ArrayOrNumber
+    aggregate_samples: Callable[[ArrayOrNumber, ArrayOrNumber], ArrayOrNumber] = None
 
     def __post_init__(self):
         # If no aggregate function is set, just average the samples
@@ -128,8 +128,8 @@ class MultipleTransmitDistances:
 
     # Mathematical operators applied to the :class:`MultipleTransmitDistances` object
     # will apply them to the ``values`` attribute as if it was just a numpy array.
-    def __truediv__(self, other) -> np.ndarray:
+    def __truediv__(self, other) -> ArrayOrNumber:
         return self.values / other
 
-    def __add__(self, other) -> np.ndarray:
+    def __add__(self, other) -> ArrayOrNumber:
         return self.values + other

--- a/vbeam/core/wavefront.py
+++ b/vbeam/core/wavefront.py
@@ -13,7 +13,7 @@ from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import distance
 
-from .element_geometry import ElementGeometry
+from .probe_geometry import ProbeGeometry
 from .wave_data import WaveData
 
 
@@ -61,7 +61,8 @@ class TransmittedWavefront(ABC):
     @abstractmethod
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> Union[float, "MultipleTransmitDistances"]:
@@ -87,8 +88,8 @@ class ReflectedWavefront:
         :class:`TransmittedWavefront`
         :func:`~vbeam.core.kernels.signal_for_point`"""
 
-    def __call__(self, point_position: np.ndarray, receiver: ElementGeometry) -> float:
-        return distance(point_position, receiver.position)
+    def __call__(self, point_position: np.ndarray, receiver: np.ndarray) -> float:
+        return distance(point_position, receiver)
 
 
 @dataclass

--- a/vbeam/data_importers/pyuff_importer.py
+++ b/vbeam/data_importers/pyuff_importer.py
@@ -102,9 +102,9 @@ def import_pyuff(
     if np.abs(modulation_frequency) == 0:
         receiver_signals = np.array(hilbert(receiver_signals), dtype="complex64")
 
-    if channel_data.probe.__class__ == 'pyuff_ustb.objects.probes.curvilinear_array.CurvilinearArray':
+    if channel_data.probe.__class__ == pyuff.objects.probes.curvilinear_array.CurvilinearArray:
         ROC_azimuth = channel_data.probe.radius
-    elif channel_data.probe.__class__ == 'pyuff_ustb.objects.probes.curvilinear_matrix_array.CurvilinearMatrixArray':
+    elif channel_data.probe.__class__ == pyuff.objects.probes.curvilinear_matrix_array.CurvilinearMatrixArray:
         ROC_azimuth = channel_data.probe.radius_x
     else:
         ROC_azimuth = 10

--- a/vbeam/data_importers/pyuff_importer.py
+++ b/vbeam/data_importers/pyuff_importer.py
@@ -2,6 +2,7 @@ from typing import List, Literal, Optional, Tuple, Union
 
 import numpy
 import pyuff_ustb as pyuff
+from fastmath import ArrayOrNumber
 from scipy.signal import hilbert
 from spekk import Spec
 
@@ -185,7 +186,7 @@ given {all_wavefronts})."
     )
 
 
-def parse_beamformed_data(beamformed_data: pyuff.BeamformedData) -> np.ndarray:
+def parse_beamformed_data(beamformed_data: pyuff.BeamformedData) -> ArrayOrNumber:
     "Parse the beamformed data from a PyUFF file into an array with the correct shape."
     imaged_points = np.squeeze(beamformed_data.data)
     scan = parse_pyuff_scan(beamformed_data.scan)

--- a/vbeam/data_importers/pyuff_importer.py
+++ b/vbeam/data_importers/pyuff_importer.py
@@ -69,6 +69,7 @@ def import_pyuff(
         4,
     ), "Shape of data assumed to be either (n_samples, n_elements, n_waves) or \
 (n_samples, n_elements, n_waves, n_frames). "
+
     # Selecting a single frame
     if isinstance(frames, int):
         if channel_data.data.ndim == 4:
@@ -95,9 +96,10 @@ def import_pyuff(
         else:
             receiver_signals = np.transpose(channel_data.data, (2, 1, 0))
             has_multiple_frames = False
+
     # Apply hilbert transform if modulation_frequency is 0
     modulation_frequency = np.array(channel_data.modulation_frequency)
-    if numpy.abs(modulation_frequency) == 0:
+    if np.abs(modulation_frequency) == 0:
         receiver_signals = np.array(hilbert(receiver_signals), dtype="complex64")
 
     if channel_data.probe.__class__ == 'pyuff_ustb.objects.probes.curvilinear_array.CurvilinearArray':
@@ -111,8 +113,7 @@ def import_pyuff(
     probe = ProbeGeometry(ROC = (ROC_azimuth, ROC_elevation))
     probe.rx_aperture_length_s = (np.max(channel_data.probe.x) - np.min(channel_data.probe.x) , np.max(channel_data.probe.y) - np.min(channel_data.probe.y))
     probe.tx_aperture_length_s = (np.max(channel_data.probe.x) - np.min(channel_data.probe.x) , np.max(channel_data.probe.y) - np.min(channel_data.probe.y))
-    
-    sender =  np.array([0.0, 0.0, 0.0], dtype="float32")
+
     receiver = np.array(channel_data.probe.xyz)
 
     sequence: List[pyuff.Wave] = channel_data.sequence
@@ -144,6 +145,7 @@ given {all_wavefronts})."
         source=np.array([wave.source.xyz for wave in sequence]),
         t0=np.array([wave.delay for wave in sequence]),
     )
+
     spec = Spec(
         {
             "signal": ["transmits", "receivers", "signal_time"],
@@ -159,9 +161,9 @@ given {all_wavefronts})."
         numpy.allclose(probe.receiver_position, wave_data.source)
     ):
         # We are dealing with a STAI dataset! Senders are each element in the array
-        probe.sender_position = probe.receiver_position.copy()
+        sender = receiver.copy()
         # One sending element for each transmitted wave
-        spec = spec.at["probe"].set(["transmits","receivers"])
+        spec = spec.at["sender"].set(["transmits"])
         # Redefine t0 to be when the wave passes through the sender position
         wave_data = wave_data.with_updates_to(
             t0=lambda t0: t0 - distance(probe.sender_position) / speed_of_sound

--- a/vbeam/data_importers/pyuff_importer.py
+++ b/vbeam/data_importers/pyuff_importer.py
@@ -155,6 +155,18 @@ given {all_wavefronts})."
         }
     )
 
+    # Set sender
+    sender = np.array(list(map(lambda x: x.origin.xyz,channel_data.sequence)),dtype="float32")
+    if sender.any():
+        # Walking aperture
+        # Redefine t0 to be when the wave passes through the sender position
+        wave_data = wave_data.with_updates_to(
+            t0=lambda t0: t0 +(distance(sender,wave_data.source)-distance(wave_data.source)) / speed_of_sound
+        )
+        spec = spec.at["sender"].set(["transmits"])
+    else:
+        sender =  np.array([0.0, 0.0, 0.0], dtype="float32")
+
     # Check if we are dealing with a STAI dataset: is each virtual source placed at
     # exactly at an element position?
     if receiver.shape == wave_data.source.shape and (

--- a/vbeam/data_importers/setup.py
+++ b/vbeam/data_importers/setup.py
@@ -136,9 +136,10 @@ updating the scan instead."
         dimensions are summed over."""
         return get_apodization_values(
             self.apodization,
+            self.probe,
             self.sender,
-            self.point_position,
             self.receiver,
+            self.point_position,
             self.wave_data,
             self.spec,
             dimensions,

--- a/vbeam/data_importers/setup.py
+++ b/vbeam/data_importers/setup.py
@@ -2,6 +2,7 @@ import warnings
 from dataclasses import dataclass
 from typing import Callable, Dict, Optional, Sequence, Union
 
+from fastmath import ArrayOrNumber
 from spekk import Spec, trees
 from spekk.util.slicing import IndicesT, slice_data, slice_spec
 
@@ -13,7 +14,6 @@ from vbeam.core import (
     SignalForPointData,
     TransmittedWavefront,
 )
-from vbeam.fastmath import numpy as np
 from vbeam.scan import Scan
 from vbeam.scan.advanced import ExtraDimsScanMixin
 from vbeam.util.transformations import *
@@ -148,7 +148,7 @@ updating the scan instead."
         self,
         apodization: Optional[Apodization] = None,
         apodization_spec: Optional[Spec] = None,
-        postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        postprocess: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
         average: bool = True,
         jit: bool = True,
         ax=None,  # : Optional[matplotlib.pyplot.Axes]
@@ -195,7 +195,7 @@ updating the scan instead."
         self,
         wavefront: Optional[TransmittedWavefront] = None,
         wavefront_spec: Optional[Spec] = None,
-        postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        postprocess: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
         ax=None,  # : Optional[matplotlib.pyplot.Axes]
     ):
         spec = self.spec.at["point_position"].set(["x", "z"])
@@ -218,7 +218,7 @@ updating the scan instead."
         self,
         wavefront: Optional[ReflectedWavefront] = None,
         wavefront_spec: Optional[Spec] = None,
-        postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        postprocess: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
         ax=None,  # : Optional[matplotlib.pyplot.Axes]
     ):
         spec = self.spec.at["point_position"].set(["x", "z"])

--- a/vbeam/fastmath/__init__.py
+++ b/vbeam/fastmath/__init__.py
@@ -1,19 +1,19 @@
 """Numpy-like API for multiple backends.
 
-This module contains an abstraction over the operations needed by the vbeam project, 
-that can be implemented by multiple backends. Current included implementations are 
+This module contains an abstraction over the operations needed by the vbeam project,
+that can be implemented by multiple backends. Current included implementations are
 Tensorflow, JAX, and Numpy. You may register custom backends using the register_backend
 function.
 
 fastmath uses a "BYOD" principle: "Bring Your Own Dependency". If you only want
-to use Tensorflow, then you only need to install Tensorflow in your project (and not 
+to use Tensorflow, then you only need to install Tensorflow in your project (and not
 JAX, for example, or any other potential backend). Setting the active_backend to your
 preferred backend should (hopefully) let you use vbeam as if it is written in that
 backend.
 
-fastmath is considered a separate, but internal project, meaning that you should not 
-depend on fastmath in your own projects (besides setting the active backend). This is to 
-ease the maintenance of the fastmath module, and only implement the operations needed 
+fastmath is considered a separate, but internal project, meaning that you should not
+depend on fastmath in your own projects (besides setting the active backend). This is to
+ease the maintenance of the fastmath module, and only implement the operations needed
 internally by vbeam.
 
 fastmath is inspired by Google's deep learning library TRAX:
@@ -36,7 +36,7 @@ Note that setting the backend sets it globally and is not thread-safe.
 import contextlib
 from typing import Callable, Dict, Optional
 
-from fastmath import api as fastmath_api
+from fastmath import ops
 
 import vbeam.util._deprecations as deprecations
 from vbeam.fastmath.backend import Backend
@@ -130,7 +130,7 @@ def proxy_backend(backend_manager: BackendManager) -> Backend:
             # Once we see that this works for our internal projects we add a deprecation warning,
             # urging users to use fastmath instead. At a breaking-change versions (vbeam 2.0.0) we
             # remove vbeam.fastmath modules.
-            return getattr(fastmath_api, attr)
+            return getattr(ops, attr)
 
     return ProxyBackend()
 

--- a/vbeam/fastmath/__init__.py
+++ b/vbeam/fastmath/__init__.py
@@ -122,3 +122,9 @@ def proxy_backend(backend_manager: BackendManager) -> Backend:
 
 backend_manager = BackendManager()
 numpy = proxy_backend(backend_manager)
+
+# Let's override the numpy with the new fastmath API for now.
+# Once we see that this works for our internal projects we add a deprecation warning,
+# urging users to use fastmath instead. At a breaking-change versions (vbeam 2.0.0) we
+# remove vbeam.fastmath modules.
+from fastmath import api as numpy

--- a/vbeam/fastmath/traceable.py
+++ b/vbeam/fastmath/traceable.py
@@ -41,6 +41,7 @@ A (long, but illustrative) example:
 ...
 >>> print(res.numpy(), tape.gradient(res, container.item.a).numpy())  # 6.0 1.0
 """
+
 from vbeam.fastmath import numpy as np
 
 
@@ -78,16 +79,26 @@ def traceable_dataclass(data_fields=(), aux_fields=()):
         # Duck-type class as a spekk treedef
         setattr(
             cls,
-            "__spekk_treedef_keys__",
+            "__fastmath_keys__",
             lambda self: (
                 *get_traceable_data_fields(self),
                 *get_traceable_aux_fields(self),
             ),
         )
-        setattr(cls, "__spekk_treedef_get__", lambda self, key: getattr(self, key))
         setattr(
             cls,
-            "__spekk_treedef_create__",
+            "__fastmath_children__",
+            lambda self: [
+                getattr(self, key)
+                for key in (
+                    *get_traceable_data_fields(self),
+                    *get_traceable_aux_fields(self),
+                )
+            ],
+        )
+        setattr(
+            cls,
+            "__fastmath_create__",
             lambda self, keys, values: cls(**dict(zip(keys, values))),
         )
 

--- a/vbeam/interpolation/fast_linear.py
+++ b/vbeam/interpolation/fast_linear.py
@@ -76,7 +76,8 @@ class FastInterpLinspace(InterpolationSpace1D):
         v = fp[clipped_i1] * p1 + fp[clipped_i2] * p2
         v = np.where(bounds_flag == -1, left, v)
         v = np.where(bounds_flag == 1, right, v)
-        v = np.moveaxis(v, 0, axis)
+        if x.ndim >= 1:
+            v = np.moveaxis(v, 0, axis)
         return v
 
     # InterpolationSpace1D interface

--- a/vbeam/interpolation/fast_linear.py
+++ b/vbeam/interpolation/fast_linear.py
@@ -6,7 +6,7 @@ from vbeam.core import InterpolationSpace1D
 from vbeam.fastmath import numpy as np
 from vbeam.util import ensure_positive_index
 
-
+from fastmath import utils
 class FastInterpLinspace(InterpolationSpace1D):
     """Interpolation for linspace.
 
@@ -55,8 +55,8 @@ class FastInterpLinspace(InterpolationSpace1D):
         bounds_flag = 0
         bounds_flag = np.where(pseudo_index < 0, -1, bounds_flag)
         bounds_flag = np.where(pseudo_index > (self.n - 1), 1, bounds_flag)
-        clipped_i1 = np.clip(i_floor, 0, self.n - 1).astype("int32")
-        clipped_i2 = np.clip(i_floor + 1, 0, self.n - 1).astype("int32")
+        clipped_i1 = np.int32(np.clip(i_floor, 0, self.n - 1))
+        clipped_i2 = np.int32(np.clip(i_floor + 1, 0, self.n - 1))
         p1, p2 = (1 - di), di
         return bounds_flag, clipped_i1, clipped_i2, p1, p2
 
@@ -68,16 +68,14 @@ class FastInterpLinspace(InterpolationSpace1D):
         right: int = 0,
         axis: int = 0,
     ) -> ArrayOrNumber:
-        fp = np.moveaxis(fp, axis, 0)
         bounds_flag, clipped_i1, clipped_i2, p1, p2 = self.interp1d_indices(x)
         bounds_flag = np.expand_dims(bounds_flag, tuple(range(1, fp.ndim)))
         p1 = np.expand_dims(p1, tuple(range(1, fp.ndim)))
         p2 = np.expand_dims(p2, tuple(range(1, fp.ndim)))
-        v = fp[clipped_i1] * p1 + fp[clipped_i2] * p2
+        #v = fp[clipped_i1] * p1 + fp[clipped_i2] * p2
+        v = utils.getitem_along_axis(fp, axis, clipped_i1) * p1+utils.getitem_along_axis(fp, axis, clipped_i2) * p2
         v = np.where(bounds_flag == -1, left, v)
         v = np.where(bounds_flag == 1, right, v)
-        if x.ndim >= 1:
-            v = np.moveaxis(v, 0, axis)
         return v
 
     # InterpolationSpace1D interface

--- a/vbeam/interpolation/fast_linear.py
+++ b/vbeam/interpolation/fast_linear.py
@@ -1,12 +1,12 @@
 from typing import Tuple
 
+from fastmath import ArrayOrNumber
+
 from vbeam.core import InterpolationSpace1D
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util import ensure_positive_index
 
 
-@traceable_dataclass(data_fields=("min", "d", "n"))
 class FastInterpLinspace(InterpolationSpace1D):
     """Interpolation for linspace.
 
@@ -18,14 +18,16 @@ class FastInterpLinspace(InterpolationSpace1D):
     n: int
 
     @staticmethod
-    def from_array(arr: np.ndarray) -> "FastInterpLinspace":
+    def from_array(arr: ArrayOrNumber) -> "FastInterpLinspace":
         # Assumes that arr was created as a linspace.
         return FastInterpLinspace(arr[0], arr[1] - arr[0], len(arr))
 
-    def to_array(self) -> np.ndarray:
+    def to_array(self) -> ArrayOrNumber:
         return np.linspace(self.min, self.min + self.d * self.n, self.n)
 
-    def interp1d_indices(self, x: np.ndarray) -> Tuple[float, int, int, float, float]:
+    def interp1d_indices(
+        self, x: ArrayOrNumber
+    ) -> Tuple[float, int, int, float, float]:
         """Return a tuple of 5 elements with information about how to interpolate the
         array.
 
@@ -60,11 +62,13 @@ class FastInterpLinspace(InterpolationSpace1D):
 
     def interp1d(
         self,
-        x: np.ndarray,
-        fp: np.ndarray,
+        x: ArrayOrNumber,
+        fp: ArrayOrNumber,
         left: int = 0,
         right: int = 0,
-    ) -> np.ndarray:
+        axis: int = 0,
+    ) -> ArrayOrNumber:
+        fp = np.moveaxis(fp, axis, 0)
         bounds_flag, clipped_i1, clipped_i2, p1, p2 = self.interp1d_indices(x)
         bounds_flag = np.expand_dims(bounds_flag, tuple(range(1, fp.ndim)))
         p1 = np.expand_dims(p1, tuple(range(1, fp.ndim)))
@@ -72,6 +76,7 @@ class FastInterpLinspace(InterpolationSpace1D):
         v = fp[clipped_i1] * p1 + fp[clipped_i2] * p2
         v = np.where(bounds_flag == -1, left, v)
         v = np.where(bounds_flag == 1, right, v)
+        v = np.moveaxis(v, 0, axis)
         return v
 
     # InterpolationSpace1D interface
@@ -88,17 +93,17 @@ class FastInterpLinspace(InterpolationSpace1D):
 
     @staticmethod
     def interp2d(
-        x: np.ndarray,
-        y: np.ndarray,
+        x: ArrayOrNumber,
+        y: ArrayOrNumber,
         xp: "FastInterpLinspace",
         yp: "FastInterpLinspace",
-        z: np.ndarray,
+        z: ArrayOrNumber,
         azimuth_axis: int = 0,
         depth_axis: int = 1,
         *,  # Remaining args must be passed by name (to avoid confusion)
         edge_handling: str = "Value",
         default_value: float = 0.0,
-    ) -> np.ndarray:
+    ) -> ArrayOrNumber:
         # Ensure that the axes are positive numbers
         azimuth_axis = ensure_positive_index(z.ndim, azimuth_axis)
         depth_axis = ensure_positive_index(z.ndim, depth_axis)
@@ -124,14 +129,16 @@ class FastInterpLinspace(InterpolationSpace1D):
         px1, px2, py1, py2 = [broadcastable(p) for p in [px1, px2, py1, py2]]
         bounds_flag_x = broadcastable(bounds_flag_x)
         bounds_flag_y = broadcastable(bounds_flag_y)
-        
+
         v0 = z[clipped_xi1, clipped_yi1] * px1 + z[clipped_xi2, clipped_yi1] * px2
         v1 = z[clipped_xi1, clipped_yi2] * px1 + z[clipped_xi2, clipped_yi2] * px2
         v = v0 * py1 + v1 * py2
-        if edge_handling=="Value":
-            v = np.where(np.logical_or(bounds_flag_x != 0, bounds_flag_y != 0), default_value, v)
-        elif edge_handling=="Nearest":
-            pass # No need to do anything, as the interpolation will choose the nearest value
+        if edge_handling == "Value":
+            v = np.where(
+                np.logical_or(bounds_flag_x != 0, bounds_flag_y != 0), default_value, v
+            )
+        elif edge_handling == "Nearest":
+            pass  # No need to do anything, as the interpolation will choose the nearest value
         else:
             raise ValueError("Only Value and Nearest edge handling is implemented")
 

--- a/vbeam/interpolation/nearest.py
+++ b/vbeam/interpolation/nearest.py
@@ -1,9 +1,9 @@
+from fastmath import ArrayOrNumber
+
 from vbeam.core import InterpolationSpace1D
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-@traceable_dataclass(data_fields=("min", "d", "n", "left", "right"))
 class NearestInterpolation(InterpolationSpace1D):
     """Interpolate by rounding (nearest neighbour).
 
@@ -20,7 +20,7 @@ class NearestInterpolation(InterpolationSpace1D):
     left: float = 0
     right: float = 0
 
-    def __call__(self, x: np.ndarray, fp: np.ndarray) -> np.ndarray:
+    def __call__(self, x: ArrayOrNumber, fp: ArrayOrNumber) -> ArrayOrNumber:
         index = np.round((x - self.min) / self.d)
         return np.select(
             [index < 0, index >= self.n],

--- a/vbeam/postprocess/__init__.py
+++ b/vbeam/postprocess/__init__.py
@@ -1,23 +1,25 @@
 from typing import Tuple, Union
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
 from vbeam.interpolation import FastInterpLinspace
 
 
-def coherence_factor(beamformed_data: np.ndarray, receivers_axis: int):
+def coherence_factor(beamformed_data: ArrayOrNumber, receivers_axis: int):
     coherent_sum = np.abs(np.sum(beamformed_data, receivers_axis)) ** 2
     incoherent_sum = np.sum(np.abs(beamformed_data) ** 2, receivers_axis)
     num_receivers = beamformed_data.shape[receivers_axis]
     return np.nan_to_num(coherent_sum / incoherent_sum / num_receivers)
 
 
-def normalized_decibels(data: np.ndarray):
+def normalized_decibels(data: ArrayOrNumber):
     "Convert the data into decibels normalized for dynamic range."
     data_db = 20 * np.nan_to_num(np.log10(np.abs(data)))
     return data_db - data_db.max()
 
 
-def _upsampling_indices(n: int, data_size: int) -> np.ndarray:
+def _upsampling_indices(n: int, data_size: int) -> ArrayOrNumber:
     """Return the sampling indices of data with size data_size after upsampling by n.
 
     The formula is a bit complicated because it is as general as possible. Check out
@@ -30,10 +32,10 @@ def _upsampling_indices(n: int, data_size: int) -> np.ndarray:
 
 
 def upsample_by_interpolation(
-    data: np.ndarray,
+    data: ArrayOrNumber,
     n: int,
     axis: Union[int, Tuple[int, ...]] = 0,
-) -> np.ndarray:
+) -> ArrayOrNumber:
     """Upsample the data along the given axes. Multiple axes may be given."""
     # No axis has been given: upsample all axes
     if axis is None:

--- a/vbeam/scan/advanced/apodization_filtered_scan.py
+++ b/vbeam/scan/advanced/apodization_filtered_scan.py
@@ -3,7 +3,7 @@ from typing import Optional, Sequence, Tuple
 from spekk import Spec
 
 from vbeam.apodization.util import get_apodization_values
-from vbeam.core import Apodization, ElementGeometry, WaveData
+from vbeam.core import Apodization, ProbeGeometry, WaveData
 from vbeam.fastmath import backend_manager
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
@@ -95,6 +95,7 @@ def recombine1(
         "base_scan",
         "apodization",
         "sender",
+        "probe",
         "receiver",
         "wave_data",
         "spec",
@@ -107,8 +108,9 @@ class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
         self,
         base_scan: Scan,
         apodization: Apodization,
-        sender: ElementGeometry,
-        receiver: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
+        receiver: np.ndarray,
         wave_data: WaveData,
         spec: Spec,
         dimensions: Sequence[str],
@@ -121,6 +123,7 @@ class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
         # For example, if a user resizes the scan then the indices must be recomputed.
         self._base_scan = base_scan
         self.apodization = apodization
+        self.probe = probe
         self.sender = sender
         self.receiver = receiver
         self.wave_data = wave_data
@@ -179,9 +182,10 @@ class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
         points = self.base_scan.get_points()
         apodization_values = get_apodization_values(
             self.apodization,
+            self.probe,
             self.sender,
-            points,
             self.receiver,
+            points,
             self.wave_data,
             self.spec,
             self.dimensions,
@@ -199,6 +203,7 @@ class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
         return ApodizationFilteredScan(
             self.base_scan,
             self.apodization,
+            self.probe,
             self.sender,
             self.receiver,
             self.wave_data,
@@ -224,6 +229,7 @@ class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
         return ApodizationFilteredScan(
             scan if scan is not None else setup.scan,
             setup.apodization,
+            setup.probe,
             setup.sender,
             setup.receiver,
             setup.wave_data,

--- a/vbeam/scan/advanced/apodization_filtered_scan.py
+++ b/vbeam/scan/advanced/apodization_filtered_scan.py
@@ -1,12 +1,12 @@
 from typing import Optional, Sequence, Tuple
 
+from fastmath import ArrayOrNumber, field
 from spekk import Spec
 
 from vbeam.apodization.util import get_apodization_values
 from vbeam.core import Apodization, ElementGeometry, WaveData
 from vbeam.fastmath import backend_manager
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.scan.advanced.base import ExtraDimsScanMixin, WrappedScan
 from vbeam.scan.base import Scan
 from vbeam.util.transformations import *
@@ -14,9 +14,9 @@ from vbeam.util.vmap import vmap_all_except
 
 
 def get_point_indices_for_transmits(
-    apodization_values: np.ndarray,
+    apodization_values: ArrayOrNumber,
     threshold: float,
-) -> Tuple[np.ndarray, np.ndarray]:
+) -> Tuple[ArrayOrNumber, ArrayOrNumber]:
     """Return the indices (and indices mask which is explained further
     down) for the points in an image that are to be imaged for a given transmit. Which
     points that are selected to be imaged are determined by the given apodization object
@@ -76,67 +76,38 @@ def get_point_indices_for_transmits(
 
 
 def recombine1(
-    image: np.ndarray,
-    imaged_points: np.ndarray,
-    indices: np.ndarray,
-    indices_mask: np.ndarray,
+    image: ArrayOrNumber,
+    imaged_points: ArrayOrNumber,
+    indices: ArrayOrNumber,
+    indices_mask: ArrayOrNumber,
     points_axis: int,
 ):
     @vmap_all_except(points_axis)
-    def recombine(imaged_points: np.ndarray) -> np.ndarray:
+    def recombine(imaged_points: ArrayOrNumber) -> ArrayOrNumber:
         return np.add.at(image, indices, imaged_points * indices_mask)
 
     return recombine(imaged_points)
 
 
-@traceable_dataclass(
-    ("_points", "_indices", "_indices_mask"),
-    (
-        "base_scan",
-        "apodization",
-        "sender",
-        "receiver",
-        "wave_data",
-        "spec",
-        "dimensions",
-        "threshold",
-    ),
-)
 class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
-    def __init__(
-        self,
-        base_scan: Scan,
-        apodization: Apodization,
-        sender: ElementGeometry,
-        receiver: ElementGeometry,
-        wave_data: WaveData,
-        spec: Spec,
-        dimensions: Sequence[str],
-        threshold: float,
-        _points: Optional[np.ndarray] = None,
-        _indices: Optional[np.ndarray] = None,
-        _indices_mask: Optional[np.ndarray] = None,
-    ):
-        # We need to store these values in case we need to recompute the indices.
-        # For example, if a user resizes the scan then the indices must be recomputed.
-        self._base_scan = base_scan
-        self.apodization = apodization
-        self.sender = sender
-        self.receiver = receiver
-        self.wave_data = wave_data
-        self.spec = spec
-        self.dimensions = dimensions
-        self.threshold = threshold
+    apodization: Apodization = field(static=True)
+    sender: ElementGeometry = field(static=True)
+    receiver: ElementGeometry = field(static=True)
+    wave_data: WaveData = field(static=True)
+    spec: Spec = field(static=True)
+    dimensions: Sequence[str] = field(static=True)
+    threshold: float = field(static=True)
+    _points: Optional[ArrayOrNumber] = None
+    _indices: Optional[ArrayOrNumber] = None
+    _indices_mask: Optional[ArrayOrNumber] = None
 
+    def __post_init__(self):
         # If any of these values are None it means we are constructing a new instance
         # (contra just copying an existing one) and we need to compute the indices.
-        self._points = _points
-        self._indices = _indices
-        self._indices_mask = _indices_mask
-        if _points is None or _indices is None or _indices_mask is None:
+        if self._points is None or self._indices is None or self._indices_mask is None:
             self._recompute_indices()
 
-    def get_points(self, flatten: bool = True) -> np.ndarray:
+    def get_points(self, flatten: bool = True) -> ArrayOrNumber:
         if not flatten:
             raise ValueError(
                 f"{self.__class__.__name__} only supports getting flattened points."
@@ -145,10 +116,10 @@ class ApodizationFilteredScan(WrappedScan, ExtraDimsScanMixin):
 
     def unflatten(
         self,
-        imaged_points: np.ndarray,
+        imaged_points: ArrayOrNumber,
         transmits_axis: int,
         points_axis: int,
-    ) -> np.ndarray:
+    ) -> ArrayOrNumber:
         recombine = np.vmap(
             recombine1,
             [None, transmits_axis, 0, 0, None],

--- a/vbeam/scan/advanced/base.py
+++ b/vbeam/scan/advanced/base.py
@@ -1,7 +1,8 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Callable, Literal, Optional, Sequence, Tuple, TypeVar, Union
 
-from vbeam.fastmath import numpy as np
+from fastmath import ArrayOrNumber, Module
+
 from vbeam.scan.base import CoordinateSystem, Scan
 
 TSelf = TypeVar("TSelf", bound="WrappedScan")
@@ -13,7 +14,7 @@ def _wrap_with_new_base_scan(wrapped_scan: TSelf, new_base_scan: Scan) -> TSelf:
     return new_copy
 
 
-class WrappedScan(Scan, ABC):
+class WrappedScan(Scan):
     """A scan that wraps another scan (the base_scan).
 
     This is useful for composing scans to make more advanced scans."""
@@ -24,12 +25,12 @@ class WrappedScan(Scan, ABC):
     def replace(
         self: TSelf,
         # "unchanged" means that the axis will not be changed.
-        **kwargs: Union[np.ndarray, None, Literal["unchanged"]],
+        **kwargs: Union[ArrayOrNumber, None, Literal["unchanged"]],
     ) -> TSelf:
         return _wrap_with_new_base_scan(self.base_scan.replace(**kwargs))
 
     def update(
-        self: TSelf, **kwargs: Optional[Callable[[np.ndarray], np.ndarray]]
+        self: TSelf, **kwargs: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]]
     ) -> TSelf:
         return _wrap_with_new_base_scan(self.base_scan.update(**kwargs))
 
@@ -37,7 +38,7 @@ class WrappedScan(Scan, ABC):
         return _wrap_with_new_base_scan(self.base_scan.resize(**kwargs))
 
     @property
-    def axes(self) -> Tuple[np.ndarray, ...]:
+    def axes(self) -> Tuple[ArrayOrNumber, ...]:
         return self.base_scan.axes
 
     @property
@@ -45,11 +46,11 @@ class WrappedScan(Scan, ABC):
         return self.base_scan.shape
 
     @property
-    def bounds(self) -> np.ndarray:
+    def bounds(self) -> ArrayOrNumber:
         return self.base_scan.bounds
 
     @property
-    def cartesian_bounds(self) -> np.ndarray:
+    def cartesian_bounds(self) -> ArrayOrNumber:
         return self.base_scan.cartesian_bounds
 
     @property
@@ -89,7 +90,7 @@ class WrappedScan(Scan, ABC):
             ) from e
 
 
-class ExtraDimsScanMixin(ABC):
+class ExtraDimsScanMixin(Module):
     """A mixin for scans that work with more than just the "points" dimension. For
     example, the
     :class:`~vbeam.scan.optimized.apodization_filtered_scan.ApodizationFilteredScan`

--- a/vbeam/scan/base.py
+++ b/vbeam/scan/base.py
@@ -1,10 +1,11 @@
 import operator
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from enum import Enum
 from functools import reduce
 from typing import Callable, Literal, Optional, Tuple, Union
 
-from vbeam.fastmath import numpy as np
+from fastmath import ArrayOrNumber, Module
+
 from vbeam.util import ensure_positive_index
 
 
@@ -13,18 +14,20 @@ class CoordinateSystem(Enum):
     POLAR = "polar"
 
 
-class Scan(ABC):
+class Scan(Module):
     @abstractmethod
-    def get_points(self, flatten: bool = True) -> np.ndarray:
+    def get_points(self, flatten: bool = True) -> ArrayOrNumber:
         """Return the points defined by the scan, flattened to a (N, 3) array by
         default, where N is the number of points."""
 
     @abstractmethod
-    def replace(self, *_axes: Union[np.ndarray, Literal["unchanged"]]) -> "Scan":
+    def replace(self, *_axes: Union[ArrayOrNumber, Literal["unchanged"]]) -> "Scan":
         "Return a copy of the scan with values replaced."
 
     @abstractmethod
-    def update(self, *_axes: Optional[Callable[[np.ndarray], np.ndarray]]) -> "Scan":
+    def update(
+        self, *_axes: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]]
+    ) -> "Scan":
         "Return a copy of the scan with updates applied to the given axes."
 
     @abstractmethod
@@ -33,7 +36,7 @@ class Scan(ABC):
 
     @property
     @abstractmethod
-    def axes(self) -> Tuple[np.ndarray, ...]:
+    def axes(self) -> Tuple[ArrayOrNumber, ...]:
         """Return the axes of the scan.
 
         E.g.: if the scan is a sector scan, return the azimuth and depths axes."""
@@ -44,7 +47,7 @@ class Scan(ABC):
         return tuple([len(axis) for axis in self.axes])
 
     @property
-    def bounds(self) -> np.ndarray:
+    def bounds(self) -> ArrayOrNumber:
         "Return the bounds of the axes of the scan."
         bounds = []
         for ax in self.axes:
@@ -53,7 +56,7 @@ class Scan(ABC):
 
     @property
     @abstractmethod
-    def cartesian_bounds(self) -> np.ndarray:
+    def cartesian_bounds(self) -> ArrayOrNumber:
         """Return the bounds in cartesian coordinates of the axes of the scan (useful
         for sector scans)."""
 
@@ -63,7 +66,9 @@ class Scan(ABC):
         """Return the coordinate system of the scan. E.g.: sector scans are in polar
         coordinates and linear scans are in cartesian coordinates."""
 
-    def unflatten(self, imaged_points: np.ndarray, points_axis: int = -1) -> np.ndarray:
+    def unflatten(
+        self, imaged_points: ArrayOrNumber, points_axis: int = -1
+    ) -> ArrayOrNumber:
         "Unflatten a flattened array of values into the original shape of the scan."
         points_axis = ensure_positive_index(imaged_points.ndim, points_axis)
         return imaged_points.reshape(

--- a/vbeam/scan/linear_scan.py
+++ b/vbeam/scan/linear_scan.py
@@ -1,19 +1,19 @@
 from typing import Callable, Literal, Optional, Tuple, Union, overload
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.scan.base import CoordinateSystem, Scan
 from vbeam.scan.util import parse_axes
 from vbeam.util.arrays import grid
 
 
-@traceable_dataclass(("x", "y", "z"))
 class LinearScan(Scan):
-    x: np.ndarray
-    y: Optional[np.ndarray]
-    z: np.ndarray
+    x: ArrayOrNumber
+    y: Optional[ArrayOrNumber]
+    z: ArrayOrNumber
 
-    def get_points(self, flatten: bool = True) -> np.ndarray:
+    def get_points(self, flatten: bool = True) -> ArrayOrNumber:
         shape = (self.num_points, 3) if flatten else (*self.shape, 3)
         y = np.array([0.0]) if self.y is None else self.y  # If the scan is 2D
         points = grid(self.x, y, self.z, shape=shape)
@@ -21,9 +21,9 @@ class LinearScan(Scan):
 
     def replace(
         self,
-        x: Union[np.ndarray, Literal["unchanged"]] = "unchanged",
-        y: Union[np.ndarray, Literal["unchanged"]] = "unchanged",
-        z: Union[np.ndarray, Literal["unchanged"]] = "unchanged",
+        x: Union[ArrayOrNumber, Literal["unchanged"]] = "unchanged",
+        y: Union[ArrayOrNumber, Literal["unchanged"]] = "unchanged",
+        z: Union[ArrayOrNumber, Literal["unchanged"]] = "unchanged",
     ) -> "LinearScan":
         return LinearScan(
             x=x if x != "unchanged" else self.x,
@@ -33,9 +33,9 @@ class LinearScan(Scan):
 
     def update(
         self,
-        x: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-        y: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-        z: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        x: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
+        y: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
+        z: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
     ) -> "LinearScan":
         return self.replace(
             x(self.x) if x is not None else "unchanged",
@@ -58,7 +58,7 @@ class LinearScan(Scan):
         )
 
     @property
-    def axes(self) -> Tuple[np.ndarray, ...]:
+    def axes(self) -> Tuple[ArrayOrNumber, ...]:
         if self.y is not None:
             return self.x, self.y, self.z
         else:
@@ -77,16 +77,16 @@ class LinearScan(Scan):
 
 
 @overload
-def linear_scan(x: np.ndarray, z: np.ndarray) -> LinearScan:
-    ...  # 2D scan
+def linear_scan(x: ArrayOrNumber, z: ArrayOrNumber) -> LinearScan: ...  # 2D scan
 
 
 @overload
-def linear_scan(x: np.ndarray, y: np.ndarray, z: np.ndarray) -> LinearScan:
-    ...  # 3D scan
+def linear_scan(
+    x: ArrayOrNumber, y: ArrayOrNumber, z: ArrayOrNumber
+) -> LinearScan: ...  # 3D scan
 
 
-def linear_scan(*xyz: np.ndarray) -> LinearScan:
+def linear_scan(*xyz: ArrayOrNumber) -> LinearScan:
     "Construct a linear scan. See LinearScan documentation for more details."
     x, y, z = parse_axes(xyz)
     return LinearScan(x, y, z)

--- a/vbeam/scan/sector_scan.py
+++ b/vbeam/scan/sector_scan.py
@@ -1,7 +1,8 @@
 from typing import Callable, Literal, Optional, Tuple, Union, overload
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.scan.base import CoordinateSystem, Scan
 from vbeam.scan.util import parse_axes, polar_bounds_to_cartesian_bounds, scan_convert
 from vbeam.util import _deprecations
@@ -9,14 +10,13 @@ from vbeam.util.arrays import grid
 from vbeam.util.coordinate_systems import as_cartesian
 
 
-@traceable_dataclass(("azimuths", "elevations", "depths", "apex"))
 class SectorScan(Scan):
-    azimuths: np.ndarray
-    elevations: Optional[np.ndarray]  # May be None for 2D scans
-    depths: np.ndarray
-    apex: np.ndarray
+    azimuths: ArrayOrNumber
+    elevations: Optional[ArrayOrNumber]  # May be None for 2D scans
+    depths: ArrayOrNumber
+    apex: ArrayOrNumber
 
-    def get_points(self, flatten: bool = True) -> np.ndarray:
+    def get_points(self, flatten: bool = True) -> ArrayOrNumber:
         polar_axis = self.elevations if self.is_3d else np.array([0.0])
         points = grid(self.azimuths, polar_axis, self.depths, shape=(*self.shape, 3))
         points = as_cartesian(points)
@@ -34,10 +34,10 @@ class SectorScan(Scan):
     def replace(
         self,
         # "unchanged" means that the axis will not be changed.
-        azimuths: Union[np.ndarray, None, Literal["unchanged"]] = "unchanged",
-        elevations: Union[np.ndarray, None, Literal["unchanged"]] = "unchanged",
-        depths: Union[np.ndarray, None, Literal["unchanged"]] = "unchanged",
-        apex: Union[np.ndarray, None, Literal["unchanged"]] = "unchanged",
+        azimuths: Union[ArrayOrNumber, None, Literal["unchanged"]] = "unchanged",
+        elevations: Union[ArrayOrNumber, None, Literal["unchanged"]] = "unchanged",
+        depths: Union[ArrayOrNumber, None, Literal["unchanged"]] = "unchanged",
+        apex: Union[ArrayOrNumber, None, Literal["unchanged"]] = "unchanged",
     ) -> "SectorScan":
         return SectorScan(
             azimuths=azimuths if azimuths != "unchanged" else self.azimuths,
@@ -48,10 +48,10 @@ class SectorScan(Scan):
 
     def update(
         self,
-        azimuths: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-        elevations: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-        depths: Optional[Callable[[np.ndarray], np.ndarray]] = None,
-        apex: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+        azimuths: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
+        elevations: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
+        depths: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
+        apex: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
     ) -> "SectorScan":
         return self.replace(
             azimuths(self.azimuths) if azimuths is not None else "unchanged",
@@ -89,7 +89,7 @@ class SectorScan(Scan):
         )
 
     @property
-    def axes(self) -> Tuple[np.ndarray, ...]:
+    def axes(self) -> Tuple[ArrayOrNumber, ...]:
         if self.elevations is not None:
             return self.azimuths, self.elevations, self.depths
         else:
@@ -109,16 +109,22 @@ class SectorScan(Scan):
     @_deprecations.renamed_kwargs("1.0.5", imaged_points="image")
     def scan_convert(
         self,
-        image: np.ndarray,
+        image: ArrayOrNumber,
         azimuth_axis: int = -2,
         depth_axis: int = -1,
         *,  # Remaining args must be passed by name (to avoid confusion)
         shape: Optional[Tuple[int, int]] = None,
-        default_value: Optional[np.ndarray] = 0.0,
-        edge_handling:str ="Value",
+        default_value: Optional[ArrayOrNumber] = 0.0,
+        edge_handling: str = "Value",
     ):
         return scan_convert(
-            image, self, azimuth_axis, depth_axis, shape=shape, default_value=default_value,edge_handling=edge_handling,
+            image,
+            self,
+            azimuth_axis,
+            depth_axis,
+            shape=shape,
+            default_value=default_value,
+            edge_handling=edge_handling,
         )
 
     @property
@@ -131,22 +137,24 @@ class SectorScan(Scan):
 
 @overload
 def sector_scan(
-    azimuths: np.ndarray,
-    depths: np.ndarray,
-    apex: Union[np.ndarray, float] = 0.0,
+    azimuths: ArrayOrNumber,
+    depths: ArrayOrNumber,
+    apex: Union[ArrayOrNumber, float] = 0.0,
 ) -> SectorScan: ...  # 2D scan
 
 
 @overload
 def sector_scan(
-    azimuths: np.ndarray,
-    elevations: np.ndarray,
-    depths: np.ndarray,
-    apex: Union[np.ndarray, float] = 0.0,
+    azimuths: ArrayOrNumber,
+    elevations: ArrayOrNumber,
+    depths: ArrayOrNumber,
+    apex: Union[ArrayOrNumber, float] = 0.0,
 ) -> SectorScan: ...  # 3D scan
 
 
-def sector_scan(*axes: np.ndarray, apex: Union[np.ndarray, float] = 0.0) -> SectorScan:
+def sector_scan(
+    *axes: ArrayOrNumber, apex: Union[ArrayOrNumber, float] = 0.0
+) -> SectorScan:
     "Construct a sector scan. See SectorScan documentation for more details."
     azimuths, elevations, depths = parse_axes(axes)
     return SectorScan(azimuths, elevations, depths, np.array(apex))

--- a/vbeam/scan/sector_scan.py
+++ b/vbeam/scan/sector_scan.py
@@ -17,7 +17,7 @@ class SectorScan(Scan):
     apex: ArrayOrNumber
 
     def get_points(self, flatten: bool = True) -> ArrayOrNumber:
-        polar_axis = self.elevations if self.is_3d else np.array([0.0])
+        polar_axis = self.elevations if self.is_3d else np.array([0.0], dtype=self.azimuths.dtype)
         points = grid(self.azimuths, polar_axis, self.depths, shape=(*self.shape, 3))
         points = as_cartesian(points)
         # Ensure that points and apex are broadcastable

--- a/vbeam/scan/util.py
+++ b/vbeam/scan/util.py
@@ -1,5 +1,7 @@
 from typing import TYPE_CHECKING, Optional, Tuple, Union
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
 from vbeam.interpolation import FastInterpLinspace
 from vbeam.util import _deprecations
@@ -93,13 +95,13 @@ def polar_bounds_to_cartesian_bounds(
 
 @_deprecations.renamed_kwargs("1.0.5", imaged_points="image", sector_scan="bounds")
 def scan_convert(
-    image: np.ndarray,
+    image: ArrayOrNumber,
     bounds: Union[Tuple[float, float, float, float], "SectorScan"],
     azimuth_axis: int = -2,
     depth_axis: int = -1,
     *,  # Remaining args must be passed by name (to avoid confusion)
     shape: Optional[Tuple[int, int]] = None,
-    default_value: Optional[np.ndarray] = 0.0,
+    default_value: Optional[ArrayOrNumber] = 0.0,
     edge_handling: str = "Value",
 ):
     from vbeam.scan import CoordinateSystem, Scan

--- a/vbeam/speed_of_sound/__init__.py
+++ b/vbeam/speed_of_sound/__init__.py
@@ -1,20 +1,16 @@
 from typing import Optional
 
 import numpy
+from fastmath import ArrayOrNumber, field
 
 from vbeam.core import SpeedOfSound
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.interpolation import FastInterpLinspace
 from vbeam.scan import Scan
 from vbeam.util import ensure_2d_point
 from vbeam.util.geometry.v2 import distance
 
 
-@traceable_dataclass(
-    data_fields=("values", "x_axis", "z_axis", "default_speed_of_sound"),
-    aux_fields=("n_samples",),
-)
 class HeterogeneousSpeedOfSound(SpeedOfSound):
     """Sample the speed of sound between sender, point, and receiver position, and
     return the average.
@@ -24,17 +20,17 @@ class HeterogeneousSpeedOfSound(SpeedOfSound):
     wave imaging, this class is not appropriate. How should speed of sound be sampled
     for these setups? That's a difficult question :)"""
 
-    values: np.ndarray
+    values: ArrayOrNumber
     x_axis: FastInterpLinspace
     z_axis: FastInterpLinspace
-    n_samples: int
+    n_samples: int = field(static=True)
     default_speed_of_sound: float = 1540.0
 
     def average(
         self,
-        sender_position: np.ndarray,
-        point_position: np.ndarray,
-        receiver_position: np.ndarray,
+        sender_position: ArrayOrNumber,
+        point_position: ArrayOrNumber,
+        receiver_position: ArrayOrNumber,
     ) -> float:
         sender_position = ensure_2d_point(sender_position)
         point_position = ensure_2d_point(point_position)
@@ -52,7 +48,7 @@ class HeterogeneousSpeedOfSound(SpeedOfSound):
         # Return the weighted average of the total distance
         return (average1 * distance1 + average2 * distance2) / total_distance
 
-    def average_between_two_points(self, p1: np.ndarray, p2: np.ndarray) -> float:
+    def average_between_two_points(self, p1: ArrayOrNumber, p2: ArrayOrNumber) -> float:
         "Return the averaged sampled speed of sound between point ``p1`` and ``p2``."
         assert p1.shape == p2.shape == (2,), "Expected p1 and p2 to be 2D points."
         x1, z1 = p1[0], p1[1]
@@ -77,7 +73,7 @@ class HeterogeneousSpeedOfSound(SpeedOfSound):
     @staticmethod
     def from_scan(
         scan: Scan,
-        values: np.ndarray,
+        values: ArrayOrNumber,
         n_samples: Optional[int] = None,
         default_speed_of_sound: float = 1540.0,
     ) -> "HeterogeneousSpeedOfSound":
@@ -99,20 +95,19 @@ class HeterogeneousSpeedOfSound(SpeedOfSound):
         )
 
 
-@traceable_dataclass(data_fields=("speed_of_sound_map", "x_axis", "z_axis", "default_speed_of_sound"))
 class DistributedGlobalSpeedOfSound(SpeedOfSound):
-    speed_of_sound_map: np.ndarray
+    speed_of_sound_map: ArrayOrNumber
     x_axis: FastInterpLinspace
     z_axis: FastInterpLinspace
     default_speed_of_sound: float = 1540.0
 
     def average(
         self,
-        sender_position: np.ndarray,
-        point_position: np.ndarray,
-        receiver_position: np.ndarray,
+        sender_position: ArrayOrNumber,
+        point_position: ArrayOrNumber,
+        receiver_position: ArrayOrNumber,
     ) -> float:
-        x, _, z = point_position[...,0], point_position[...,1], point_position[...,2]
+        x, _, z = point_position[..., 0], point_position[..., 1], point_position[..., 2]
         interpolated_speed_of_sound_samples = FastInterpLinspace.interp2d(
             x=x,
             y=z,

--- a/vbeam/speed_of_sound/__init__.py
+++ b/vbeam/speed_of_sound/__init__.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 import numpy
-from fastmath import ArrayOrNumber, Array,field
+from fastmath import ArrayOrNumber, Array, field
 
 from vbeam.core import SpeedOfSound
 from vbeam.fastmath import numpy as np
@@ -29,7 +29,7 @@ class HeterogeneousSpeedOfSound(SpeedOfSound):
     def average(
         self,
         sender_position: Array,
-        sender: Array,
+        point_position: Array,
         receiver_position: Array,
     ) -> float:
         sender_position = ensure_2d_point(sender_position)
@@ -104,7 +104,7 @@ class DistributedGlobalSpeedOfSound(SpeedOfSound):
     def average(
         self,
         sender_position: Array,
-        sender: Array,
+        point_position: Array,
         receiver_position: Array,
     ) -> float:
         x, _, z = point_position[..., 0], point_position[..., 1], point_position[..., 2]

--- a/vbeam/util/__init__.py
+++ b/vbeam/util/__init__.py
@@ -1,8 +1,6 @@
 from typing import Sequence, Union
 
-from fastmath import ArrayOrNumber
-
-from vbeam.fastmath import numpy as np
+from fastmath import ArrayOrNumber, api
 
 
 def ensure_positive_index(n: int, index: Union[int, Sequence[int]]) -> int:
@@ -26,6 +24,6 @@ def ensure_2d_point(point: ArrayOrNumber) -> ArrayOrNumber:
     if point.shape[-1] == 2:
         return point
     elif point.shape[-1] == 3:
-        return point[..., np.array([0, 2])]  # Return x- and z-coordinates
+        return point[..., api.array([0, 2])]  # Return x- and z-coordinates
     else:
         raise ValueError(f"Expected 2D or 3D point, got shape={point.shape}.")

--- a/vbeam/util/__init__.py
+++ b/vbeam/util/__init__.py
@@ -15,6 +15,13 @@ def ensure_positive_index(n: int, index: Union[int, Sequence[int]]) -> int:
         return [ensure_positive_index(n, i) for i in index]
 
 
+def broadcast_to_axis(a: ArrayOrNumber, axis: int, ndims: int) -> ArrayOrNumber:
+    assert a.ndim <= 1
+    shape = [1] * ndims
+    shape[axis] = -1
+    return a.reshape(shape)
+
+
 def ensure_2d_point(point: ArrayOrNumber) -> ArrayOrNumber:
     if point.shape[-1] == 2:
         return point

--- a/vbeam/util/__init__.py
+++ b/vbeam/util/__init__.py
@@ -1,5 +1,7 @@
 from typing import Sequence, Union
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
 
 
@@ -13,7 +15,7 @@ def ensure_positive_index(n: int, index: Union[int, Sequence[int]]) -> int:
         return [ensure_positive_index(n, i) for i in index]
 
 
-def ensure_2d_point(point: np.ndarray) -> np.ndarray:
+def ensure_2d_point(point: ArrayOrNumber) -> ArrayOrNumber:
     if point.shape[-1] == 2:
         return point
     elif point.shape[-1] == 3:

--- a/vbeam/util/__init__.py
+++ b/vbeam/util/__init__.py
@@ -1,6 +1,6 @@
 from typing import Sequence, Union
 
-from fastmath import ArrayOrNumber, api
+from fastmath import ArrayOrNumber, ops
 
 
 def ensure_positive_index(n: int, index: Union[int, Sequence[int]]) -> int:
@@ -24,6 +24,6 @@ def ensure_2d_point(point: ArrayOrNumber) -> ArrayOrNumber:
     if point.shape[-1] == 2:
         return point
     elif point.shape[-1] == 3:
-        return point[..., api.array([0, 2])]  # Return x- and z-coordinates
+        return point[..., ops.array([0, 2])]  # Return x- and z-coordinates
     else:
         raise ValueError(f"Expected 2D or 3D point, got shape={point.shape}.")

--- a/vbeam/util/_default_values.py
+++ b/vbeam/util/_default_values.py
@@ -7,14 +7,19 @@ from typing import Tuple
 
 from spekk import Spec
 
-from vbeam.core import ElementGeometry, WaveData
+from vbeam.core import ProbeGeometry, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.util.arrays import grid
 
 
-def _default_sender(spec: Spec) -> Tuple[ElementGeometry, Spec]:
-    return ElementGeometry(np.array([0, 0, 0]), 0.0, 0.0), spec.at["sender"].set([])
+def _default_probe(spec: Spec) -> Tuple[ProbeGeometry, Spec]:
+    return ProbeGeometry(np.zeros(3),np.zeros(3),10), spec.at["probe"].set([])
 
+def _default_receiver(spec: Spec) -> Tuple[np.ndarray, Spec]:
+    return np.zeros(3), spec.at["receiver"].set([])
+
+def _default_sender(spec: Spec) -> Tuple[np.ndarray, Spec]:
+    return np.zeros(3), spec.at["sender"].set([])
 
 def _default_point_position(spec: Spec) -> Tuple[np.ndarray, Spec]:
     nx, nz = 200, 200
@@ -27,11 +32,8 @@ def _default_point_position(spec: Spec) -> Tuple[np.ndarray, Spec]:
     return point_position, spec.at["point_position"].set(["x", "z"])
 
 
-def _default_receiver(spec: Spec) -> Tuple[ElementGeometry, Spec]:
-    return ElementGeometry(np.array([0, 0, 0]), 0.0, 0.0), spec.at["receiver"].set([])
 
-
-def _default_wave_data(spec: Spec) -> Tuple[ElementGeometry, Spec]:
+def _default_wave_data(spec: Spec) -> Tuple[WaveData, Spec]:
     return WaveData(np.array([5e-3, 0, 20e-3]), 0.0, 0.0, 0.0), spec.at[
         "wave_data"
     ].set([])

--- a/vbeam/util/_default_values.py
+++ b/vbeam/util/_default_values.py
@@ -5,6 +5,7 @@ Each function returns the default value and its spec."""
 
 from typing import Tuple
 
+from fastmath import ArrayOrNumber
 from spekk import Spec
 
 from vbeam.core import ElementGeometry, WaveData
@@ -16,7 +17,7 @@ def _default_sender(spec: Spec) -> Tuple[ElementGeometry, Spec]:
     return ElementGeometry(np.array([0, 0, 0]), 0.0, 0.0), spec.at["sender"].set([])
 
 
-def _default_point_position(spec: Spec) -> Tuple[np.ndarray, Spec]:
+def _default_point_position(spec: Spec) -> Tuple[ArrayOrNumber, Spec]:
     nx, nz = 200, 200
     point_position = grid(
         np.linspace(-20e-3, 20e-3, nx),

--- a/vbeam/util/_deprecations.py
+++ b/vbeam/util/_deprecations.py
@@ -1,4 +1,8 @@
-from typing import TypeVar
+import warnings
+
+
+def warn(msg, stacklevel=3):
+    warnings.warn(msg, DeprecationWarning, stacklevel=stacklevel)
 
 
 def _get_function_name(f: callable):
@@ -28,7 +32,7 @@ def renamed_kwargs(version: str, **renamed_kwargs: str):
             new_kwargs = {}
             for k, v in kwargs.items():
                 if k in renamed_kwargs:
-                    print(
+                    warn(
                         f"Deprecation warning: argument '{k}' of "
                         f"{_get_function_name(f)} was renamed to '{renamed_kwargs[k]}' "
                         f"in version {version}."

--- a/vbeam/util/apply_windowed.py
+++ b/vbeam/util/apply_windowed.py
@@ -1,12 +1,14 @@
 from typing import Callable, Tuple
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
 
 
 def get_window_indices(
     image_shape: Tuple[int, ...],
     window_radius: Tuple[int, ...],
-) -> np.ndarray:
+) -> ArrayOrNumber:
     indices = np.stack(
         np.meshgrid(*(np.arange(0, s) for s in image_shape), indexing="ij"), -1
     )
@@ -18,7 +20,7 @@ def get_window_indices(
     return indices + indices_window_offset
 
 
-def windowed(f: Callable, window_radius: Tuple[int, ...]) -> np.ndarray:
+def windowed(f: Callable, window_radius: Tuple[int, ...]) -> ArrayOrNumber:
     def apply_windowed(image, *args, **kwargs):
         indices = get_window_indices(image.shape, window_radius)
 

--- a/vbeam/util/arrays.py
+++ b/vbeam/util/arrays.py
@@ -1,9 +1,11 @@
 from typing import Optional, Sequence
 
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
 
 
-def grid(*axes: np.ndarray, shape: Optional[Sequence[int]] = None) -> np.ndarray:
+def grid(*axes: ArrayOrNumber, shape: Optional[Sequence[int]] = None) -> ArrayOrNumber:
     """Return an array of each point position, organized in a grid.
 
     >>> x, z = np.array([1,2,3]), np.array([1,2,3,4])

--- a/vbeam/util/coordinate_systems.py
+++ b/vbeam/util/coordinate_systems.py
@@ -1,7 +1,9 @@
+from fastmath import ArrayOrNumber
+
 from vbeam.fastmath import numpy as np
 
 
-def as_polar(cartesian_point: np.ndarray):
+def as_polar(cartesian_point: ArrayOrNumber):
     """Return a point in cartesian coordinates in its polar coordinates representation.
 
     NOTE: All y-values must be 0. FIXME"""
@@ -11,7 +13,7 @@ def as_polar(cartesian_point: np.ndarray):
     return np.stack([azimuth_angles, np.zeros(radii.shape), radii], -1)
 
 
-def as_cartesian(polar_point: np.ndarray):
+def as_cartesian(polar_point: ArrayOrNumber):
     "Return a point in polar coordinates in its cartesian coordinates representation."
     azimuth_angles = polar_point[..., 0]
     polar_angles = polar_point[..., 1]
@@ -29,7 +31,7 @@ def as_cartesian(polar_point: np.ndarray):
 def applied_in_polar_coordinates(f):
     """Wrap a function that takes and returns a point in polar coordinates such that it
     takes and returns a point in cartesian coordinates instead.
-    
+
     Usage:
     >>> import numpy as np
     >>> @applied_in_polar_coordinates
@@ -39,6 +41,7 @@ def applied_in_polar_coordinates(f):
     >>> add_radius(cartesian_point, 1)
     array([3.6, 0. , 4.8])
     """
+
     def inner(p, *args, **kwargs):
         return as_cartesian(f(as_polar(p), *args, **kwargs))
 
@@ -48,7 +51,7 @@ def applied_in_polar_coordinates(f):
 def applied_in_cartesian_coordinates(f):
     """Wrap a function that takes and returns a point in cartesian coordinates such that
     it takes and returns a point in polar coordinates instead.
-    
+
     Usage:
     >>> import numpy as np
     >>> @applied_in_cartesian_coordinates
@@ -58,6 +61,7 @@ def applied_in_cartesian_coordinates(f):
     >>> move_x(polar_point, 1)
     array([1.57079633, 0.        , 2.        ])
     """
+
     def inner(p, *args, **kwargs):
         return as_polar(f(as_cartesian(p), *args, **kwargs))
 

--- a/vbeam/util/geometry/line.py
+++ b/vbeam/util/geometry/line.py
@@ -28,14 +28,15 @@ class Line(Module):
     def from_anchor_and_angle(anchor: ArrayOrNumber, angle: float) -> "Line":
         "Construct a line that passes through the anchor and has the given angle."
         return Line.passing_through(
-            anchor, anchor + np.array([np.cos(angle), 0, np.sin(angle)])
+            anchor, anchor + np.stack([np.cos(angle), np.zeros(shape=angle.shape, dtype=angle.dtype), np.sin(angle)])
         )
 
     def intersection(l1: "Line", l2: "Line") -> ArrayOrNumber:
         "Return the point where the lines l1 and l2 intersect."
         x = (l1.b * l2.c - l2.b * l1.c) / (l1.a * l2.b - l2.a * l1.b)
+        y = np.zeros(shape=x.shape, dtype=x.dtype)
         z = (l2.a * l1.c - l1.a * l2.c) / (l1.a * l2.b - l2.a * l1.b)
-        return np.array([x, 0, z])
+        return np.stack([x, y, z], axis=-1) 
 
     @property
     def angle(self):

--- a/vbeam/util/geometry/line.py
+++ b/vbeam/util/geometry/line.py
@@ -1,9 +1,9 @@
+from fastmath import ArrayOrNumber, Module
+
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-@traceable_dataclass(("a", "b", "c"))
-class Line:
+class Line(Module):
     """A line as defined by a*x + b*z + c = 0.
 
     Note that only 2D lines are supported but all point-parameters and returned points
@@ -15,7 +15,7 @@ class Line:
     c: float
 
     @staticmethod
-    def passing_through(point1: np.ndarray, point2: np.ndarray) -> "Line":
+    def passing_through(point1: ArrayOrNumber, point2: ArrayOrNumber) -> "Line":
         "Construct a line that passes through both point1 and point2."
         x1, y1, z1 = point1
         x2, y2, z2 = point2
@@ -25,13 +25,13 @@ class Line:
         return Line(a, b, c)
 
     @staticmethod
-    def from_anchor_and_angle(anchor: np.ndarray, angle: float) -> "Line":
+    def from_anchor_and_angle(anchor: ArrayOrNumber, angle: float) -> "Line":
         "Construct a line that passes through the anchor and has the given angle."
         return Line.passing_through(
             anchor, anchor + np.array([np.cos(angle), 0, np.sin(angle)])
         )
 
-    def intersection(l1: "Line", l2: "Line") -> np.ndarray:
+    def intersection(l1: "Line", l2: "Line") -> ArrayOrNumber:
         "Return the point where the lines l1 and l2 intersect."
         x = (l1.b * l2.c - l2.b * l1.c) / (l1.a * l2.b - l2.a * l1.b)
         z = (l2.a * l1.c - l1.a * l2.c) / (l1.a * l2.b - l2.a * l1.b)
@@ -42,7 +42,7 @@ class Line:
         "The angle of the line."
         return np.arctan2(self.b, self.a)
 
-    def signed_distance(self, point: np.ndarray) -> float:
+    def signed_distance(self, point: ArrayOrNumber) -> float:
         """Return the signed distance between the point and the nearest point on the
         line.
 

--- a/vbeam/util/geometry/v2.py
+++ b/vbeam/util/geometry/v2.py
@@ -2,12 +2,12 @@
 
 It's all in this one module because it's all so closely related."""
 
-
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Optional, Tuple, Union
 
+from fastmath import ArrayOrNumber, Module
+
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 ####
 # Functions for calculating intersections.
@@ -16,7 +16,7 @@ from vbeam.fastmath.traceable import traceable_dataclass
 
 def intersect_line_line(
     line1: "Line", line2: "Line"
-) -> Tuple[int, Tuple[np.ndarray, np.ndarray]]:
+) -> Tuple[int, Tuple[ArrayOrNumber, ArrayOrNumber]]:
     num_intersections = np.where(np.cross(line1.direction, line2.direction) == 0, 0, 1)
     return num_intersections, (
         line1.anchor
@@ -28,7 +28,7 @@ def intersect_line_line(
 
 def intersect_circle_line(
     circle: "Circle", line: "Line"
-) -> Tuple[int, Tuple[np.ndarray, np.ndarray]]:
+) -> Tuple[int, Tuple[ArrayOrNumber, ArrayOrNumber]]:
     # http://paulbourke.net/geometry/circlesphere/
     a = np.sum(line.direction**2)
     b = 2 * np.sum((line.direction * (line.anchor - circle.center)))
@@ -53,12 +53,14 @@ def intersect_circle_line(
 # Some helper functions
 
 
-def distance(point1: np.ndarray, point2: Optional[np.ndarray] = None, axis: int = -1):
+def distance(
+    point1: ArrayOrNumber, point2: Optional[ArrayOrNumber] = None, axis: int = -1
+):
     diff = point1 if point2 is None else point2 - point1
     return np.sqrt(np.sum(diff**2, axis=axis))
 
 
-def rotate(point: np.ndarray, theta: float, phi: float) -> np.ndarray:
+def rotate(point: ArrayOrNumber, theta: float, phi: float) -> ArrayOrNumber:
     # Define the rotation matrices
     rotation_matrix_theta = np.array(
         [
@@ -77,15 +79,16 @@ def rotate(point: np.ndarray, theta: float, phi: float) -> np.ndarray:
     # Rotate the point
     return rotation_matrix_theta @ rotation_matrix_phi @ point
 
+
 ####
 # Curve classes
 
 
-class Curve(ABC):
+class Curve(Module):
     """A 2D curve. See method docstrings for details."""
 
     @abstractmethod
-    def __call__(self, t: Union[float, np.ndarray]) -> Tuple[float, float]:
+    def __call__(self, t: Union[float, ArrayOrNumber]) -> Tuple[float, float]:
         """Evaluate the curve at a given parameter value.
 
         For example, evaluating a circle at t=0 gives the point at angle 0, t=pi/2 gives
@@ -95,7 +98,7 @@ class Curve(ABC):
         given point."""
 
     @abstractmethod
-    def signed_distance(self, point: np.ndarray) -> np.ndarray:
+    def signed_distance(self, point: ArrayOrNumber) -> ArrayOrNumber:
         """Return the signed distance from a point to the nearest point on the curve.
 
         The sign of the returned value gives information about which side of the curve
@@ -104,39 +107,42 @@ class Curve(ABC):
         outside, and negative on the inside."""
 
     @abstractmethod
-    def intersect(self, other: "Curve") -> Tuple[int, Tuple[np.ndarray, np.ndarray]]:
+    def intersect(
+        self, other: "Curve"
+    ) -> Tuple[int, Tuple[ArrayOrNumber, ArrayOrNumber]]:
         """Return the number of intersections between this curve and another curve and
         the (potentially none) intersection points."""
 
 
-@traceable_dataclass(("anchor", "direction"))
 class Line(Curve):
-    anchor: np.ndarray
-    direction: np.ndarray
+    anchor: ArrayOrNumber
+    direction: ArrayOrNumber
 
     def __post_init__(self):
         # Normalize direction vector (tangent)
         self.direction = self.direction / distance(self.direction)
 
-    def __call__(self, t: Union[float, np.ndarray]) -> Tuple[float, float]:
+    def __call__(self, t: Union[float, ArrayOrNumber]) -> Tuple[float, float]:
         if np.is_ndarray(t) and t.ndim != 0:
             points = np.moveaxis(self.anchor + t[..., None] * self.direction, -1, 0)
         else:
             points = self.anchor + t * self.direction
         return points
 
-    def signed_distance(self, point: np.ndarray) -> float:
+    def signed_distance(self, point: ArrayOrNumber) -> float:
         return np.cross(point - self.anchor, self.direction)
 
     @staticmethod
-    def passing_through(point1: np.ndarray, point2: np.ndarray) -> "Line":
+    def passing_through(point1: ArrayOrNumber, point2: ArrayOrNumber) -> "Line":
         return Line(point1, point2 - point1)
 
     @staticmethod
-    def with_angle(anchor: np.ndarray, angle: float) -> "Line":
+    def with_angle(anchor: ArrayOrNumber, angle: float) -> "Line":
         return Line(anchor, np.array([np.cos(angle), np.sin(angle)]))
 
-    def intersect(self, other: Curve) -> Tuple[int, Tuple[np.ndarray, np.ndarray]]:
+    def intersect(
+        self, other: Curve
+    ) -> Tuple[int, Tuple[ArrayOrNumber, ArrayOrNumber]]:
         if isinstance(other, Line):
             return intersect_line_line(self, other)
         else:
@@ -147,13 +153,12 @@ class Line(Curve):
         return np.arctan2(self.direction[1], self.direction[0])
 
     @property
-    def normal(self) -> np.ndarray:
+    def normal(self) -> ArrayOrNumber:
         return np.array([-self.direction[1], self.direction[0]])
 
 
-@traceable_dataclass(("center", "radius"))
 class Circle(Curve):
-    center: np.ndarray
+    center: ArrayOrNumber
     radius: float
 
     def __call__(self, t: float) -> Tuple[float, float]:
@@ -162,17 +167,18 @@ class Circle(Curve):
             center = self.center[:, None]
         return np.array([np.cos(t), np.sin(t)]) * self.radius + center
 
-    def signed_distance(self, point: np.ndarray) -> np.ndarray:
+    def signed_distance(self, point: ArrayOrNumber) -> ArrayOrNumber:
         return distance(point, self.center) - self.radius
 
-    def intersect(self, other: Curve) -> Tuple[int, Tuple[np.ndarray, np.ndarray]]:
+    def intersect(
+        self, other: Curve
+    ) -> Tuple[int, Tuple[ArrayOrNumber, ArrayOrNumber]]:
         if isinstance(other, Line):
             return intersect_circle_line(self, other)
         else:
             raise NotImplementedError
 
 
-@traceable_dataclass(("f1", "f2", "d"))
 class Ellipse(Curve):
     """An ellipse defined by two focus points and the summed distance from each to
     points on the ellipse.
@@ -185,11 +191,11 @@ class Ellipse(Curve):
     should also not depend on the derivative of the __call__ method to compute a
     normalized tangent."""
 
-    f1: np.ndarray  # Focus point 1
-    f2: np.ndarray  # Focus point 2
+    f1: ArrayOrNumber  # Focus point 1
+    f2: ArrayOrNumber  # Focus point 2
     d: float  # If p is a point on the ellipse, then d = distance(p, f1) + distance(p, f2)
 
-    def __call__(self, t: np.ndarray) -> np.ndarray:
+    def __call__(self, t: ArrayOrNumber) -> ArrayOrNumber:
         # An ellipse is just a transformed circle
         circle = Circle(np.array([0, 0]), 1)
         circle_transform = self._circle_transform
@@ -197,12 +203,14 @@ class Ellipse(Curve):
             circle_transform = np.vmap(circle_transform, [1])
         return circle_transform(circle(t)).T
 
-    def signed_distance(self, point: np.ndarray) -> np.ndarray:
+    def signed_distance(self, point: ArrayOrNumber) -> ArrayOrNumber:
         # Not implemented yet. Need to think about how to normalize the distance since
         # the space is transformed.
         raise NotImplementedError
 
-    def intersect(self, other: Curve) -> Tuple[int, Tuple[np.ndarray, np.ndarray]]:
+    def intersect(
+        self, other: Curve
+    ) -> Tuple[int, Tuple[ArrayOrNumber, ArrayOrNumber]]:
         if isinstance(other, Line):
             other = Line.passing_through(
                 self._circle_undo_transform(other(0)),
@@ -221,21 +229,21 @@ class Ellipse(Curve):
     def _circle_rotation(self) -> float:
         return np.arctan2(self.f2[1] - self.f1[1], self.f2[0] - self.f1[0])
 
-    def _circle_scale(self) -> np.ndarray:
+    def _circle_scale(self) -> ArrayOrNumber:
         a = self.d / 2
         b = np.sqrt(a**2 - distance(self.f2, self.f1) ** 2 / 4)
         return np.array([a, b])
 
-    def _circle_translation(self) -> np.ndarray:
+    def _circle_translation(self) -> ArrayOrNumber:
         return (self.f1 + self.f2) / 2
 
-    def _circle_transform(self, point: np.ndarray) -> np.ndarray:
+    def _circle_transform(self, point: ArrayOrNumber) -> ArrayOrNumber:
         point *= self._circle_scale()
         point = rotate(point, self._circle_rotation())
         point += self._circle_translation()
         return point
 
-    def _circle_undo_transform(self, point: np.ndarray) -> np.ndarray:
+    def _circle_undo_transform(self, point: ArrayOrNumber) -> ArrayOrNumber:
         point -= self._circle_translation()
         point = rotate(point, -self._circle_rotation())
         point /= self._circle_scale()

--- a/vbeam/util/vmap.py
+++ b/vbeam/util/vmap.py
@@ -1,7 +1,7 @@
-from dataclasses import dataclass
 from functools import partial
 from typing import Callable, Optional, Sequence, Union
 
+from fastmath import ArrayOrNumber
 from spekk import Spec
 
 from vbeam.fastmath import numpy as np
@@ -22,7 +22,7 @@ def vmap_all_except(f: Union[Callable, int], axis: Optional[int] = None):
             raise ValueError("axis must be an int when using @vmap_all_except().")
         return partial(vmap_all_except, axis=f)
 
-    def wrapped(x: np.ndarray):
+    def wrapped(x: ArrayOrNumber):
         if x.ndim == 1:
             return f(x)
 
@@ -55,11 +55,11 @@ def vmap_all_except(f: Union[Callable, int], axis: Optional[int] = None):
 
 
 def apply_binary_operation_across_axes(
-    a: np.ndarray,
-    b: np.ndarray,
-    binary_operation: Callable[[np.ndarray, np.ndarray], np.ndarray],
+    a: ArrayOrNumber,
+    b: ArrayOrNumber,
+    binary_operation: Callable[[ArrayOrNumber, ArrayOrNumber], ArrayOrNumber],
     axes: Sequence[int],
-) -> np.ndarray:
+) -> ArrayOrNumber:
     """Apply a binary operation to two arrays, where the second array is potentially
     broadcasted and transposed to match the shape and axis-ordering of the first array.
 

--- a/vbeam/wavefront/focused.py
+++ b/vbeam/wavefront/focused.py
@@ -1,4 +1,4 @@
-from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
+from vbeam.core import TransmittedWavefront, WaveData,ProbeGeometry
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.wavefront.plane import PlaneWavefront
@@ -8,14 +8,15 @@ from vbeam.wavefront.plane import PlaneWavefront
 class FocusedSphericalWavefront(TransmittedWavefront):
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
-        sender_source_dist = np.sqrt(np.sum((sender.position - wave_data.source) ** 2))
+        sender_source_dist = np.sqrt(np.sum((sender - wave_data.source) ** 2))
         source_point_dist = np.sqrt(np.sum((wave_data.source - point_position) ** 2))
         return sender_source_dist * np.sign(
-            wave_data.source[2] - sender.position[2]
+            wave_data.source[2] - sender[2]
         ) - source_point_dist * np.sign(wave_data.source[2] - point_position[2])
 
 
@@ -25,15 +26,16 @@ class FocusedHybridWavefront(TransmittedWavefront):
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
         spherical_wavefront = FocusedSphericalWavefront()
         plane_wavefront = PlaneWavefront()
         wave_data.azimuth = np.arctan2(
-            wave_data.source[0] - sender.position[0],
-            wave_data.source[2] - sender.position[2],
+            wave_data.source[0] - sender[0],
+            wave_data.source[2] - sender[2],
         )
         wave_data.elevation = np.arctan2(
             wave_data.source[1] - sender.position[1],
@@ -41,8 +43,8 @@ class FocusedHybridWavefront(TransmittedWavefront):
         )
         return np.where(
             np.abs(point_position[2] - wave_data.source[2]) > self.pw_margin,
-            spherical_wavefront(sender, point_position, wave_data),
-            plane_wavefront(sender, point_position, wave_data),
+            spherical_wavefront(probe,sender, point_position, wave_data),
+            plane_wavefront(probe,sender, point_position, wave_data),
         )
 
 

--- a/vbeam/wavefront/focused.py
+++ b/vbeam/wavefront/focused.py
@@ -54,20 +54,20 @@ class FocusedBlendedWavefront(TransmittedWavefront):
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
         spherical_wavefront = FocusedSphericalWavefront()
         plane_wavefront = PlaneWavefront()
         wave_data.azimuth = np.arctan2(
-            wave_data.source[0] - sender.position[0],
-            wave_data.source[2] - sender.position[2],
+            wave_data.source[0] - sender[0],
+            wave_data.source[2] - sender[2],
         )
 
         wave_data.elevation = np.arctan2(
-            wave_data.source[1] - sender.position[1],
-            wave_data.source[2] - sender.position[2],
+            wave_data.source[1] - sender[1],
+            wave_data.source[2] - sender[2],
         )
         source_point_dist = np.sqrt(np.sum((wave_data.source - point_position) ** 2))
         normalized_distance = np.clip(

--- a/vbeam/wavefront/plane.py
+++ b/vbeam/wavefront/plane.py
@@ -1,14 +1,14 @@
+from fastmath import ArrayOrNumber
+
 from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 
 
-@traceable_dataclass()
 class PlaneWavefront(TransmittedWavefront):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         wave_data: WaveData,
     ) -> float:
         diff = point_position - sender.position

--- a/vbeam/wavefront/plane.py
+++ b/vbeam/wavefront/plane.py
@@ -1,4 +1,4 @@
-from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
+from vbeam.core import TransmittedWavefront, WaveData, ProbeGeometry
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 
@@ -7,11 +7,12 @@ from vbeam.fastmath.traceable import traceable_dataclass
 class PlaneWavefront(TransmittedWavefront):
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
-        diff = point_position - sender.position
+        diff = point_position - sender
         x, y, z = diff[0], diff[1], diff[2]
         return (
             x * np.sin(wave_data.azimuth) * np.cos(wave_data.elevation)

--- a/vbeam/wavefront/plotting.py
+++ b/vbeam/wavefront/plotting.py
@@ -1,5 +1,6 @@
 from typing import Callable, Optional
 
+from fastmath import ArrayOrNumber
 from spekk import Spec
 
 from vbeam.core import (
@@ -8,7 +9,6 @@ from vbeam.core import (
     TransmittedWavefront,
     WaveData,
 )
-from vbeam.fastmath import numpy as np
 from vbeam.util._default_values import (
     _default_point_position,
     _default_receiver,
@@ -24,10 +24,10 @@ from vbeam.wavefront.util import (
 def plot_transmitted_wavefront(
     wavefront: TransmittedWavefront,
     sender: Optional[ElementGeometry] = None,
-    point_position: Optional[np.ndarray] = None,
+    point_position: Optional[ArrayOrNumber] = None,
     wave_data: Optional[WaveData] = None,
     spec: Optional[Spec] = None,
-    postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+    postprocess: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
     ax=None,  # : Optional[matplotlib.pyplot.Axes]
 ):
     """Plot the (transmit) wavefront distance values using ``matplotlib``.
@@ -75,10 +75,10 @@ def plot_transmitted_wavefront(
 
 def plot_reflected_wavefront(
     wavefront: ReflectedWavefront,
-    point_position: Optional[np.ndarray] = None,
+    point_position: Optional[ArrayOrNumber] = None,
     receiver: Optional[ElementGeometry] = None,
     spec: Optional[Spec] = None,
-    postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
+    postprocess: Optional[Callable[[ArrayOrNumber], ArrayOrNumber]] = None,
     ax=None,  # : Optional[matplotlib.pyplot.Axes]
 ):
     """Plot the (receive) wavefront distance values using ``matplotlib``.

--- a/vbeam/wavefront/plotting.py
+++ b/vbeam/wavefront/plotting.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 from spekk import Spec
 
 from vbeam.core import (
-    ElementGeometry,
+    ProbeGeometry,
     ReflectedWavefront,
     TransmittedWavefront,
     WaveData,
@@ -11,6 +11,7 @@ from vbeam.core import (
 from vbeam.fastmath import numpy as np
 from vbeam.util._default_values import (
     _default_point_position,
+    _default_probe,
     _default_receiver,
     _default_sender,
     _default_wave_data,
@@ -23,7 +24,8 @@ from vbeam.wavefront.util import (
 
 def plot_transmitted_wavefront(
     wavefront: TransmittedWavefront,
-    sender: Optional[ElementGeometry] = None,
+    probe: ProbeGeometry = None,
+    sender: np.ndarray = None,
     point_position: Optional[np.ndarray] = None,
     wave_data: Optional[WaveData] = None,
     spec: Optional[Spec] = None,
@@ -36,6 +38,8 @@ def plot_transmitted_wavefront(
     to process the values further before plotting (for example scan conversion)."""
     # Try to set helpful default values
     spec = spec if spec is not None else Spec({})
+    if probe is None:
+        probe, spec = _default_probe(spec)
     if sender is None:
         sender, spec = _default_sender(spec)
     if point_position is None:
@@ -46,6 +50,7 @@ def plot_transmitted_wavefront(
     # Calculate wavefront values
     vals = get_transmitted_wavefront_values(
         wavefront,
+        probe,
         sender,
         point_position,
         wave_data,
@@ -76,7 +81,7 @@ def plot_transmitted_wavefront(
 def plot_reflected_wavefront(
     wavefront: ReflectedWavefront,
     point_position: Optional[np.ndarray] = None,
-    receiver: Optional[ElementGeometry] = None,
+    receiver: Optional[np.ndarray] = None,
     spec: Optional[Spec] = None,
     postprocess: Optional[Callable[[np.ndarray], np.ndarray]] = None,
     ax=None,  # : Optional[matplotlib.pyplot.Axes]
@@ -90,7 +95,7 @@ def plot_reflected_wavefront(
     if point_position is None:
         point_position, spec = _default_point_position(spec)
     if receiver is None:
-        receiver, spec = _default_receiver(spec)
+        reveiver, spec = _default_receiver(spec)
 
     # Calculate wavefront values
     vals = get_reflected_wavefront_values(

--- a/vbeam/wavefront/refocus.py
+++ b/vbeam/wavefront/refocus.py
@@ -1,17 +1,16 @@
+from fastmath import ArrayOrNumber
+
 from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
-from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import distance
 
 
-@traceable_dataclass(("base_wavefront", "base_sender", "compensation_scalar"))
 class REFoCUSWavefront(TransmittedWavefront):
     """A time-domain REFoCUS wavefront model.
 
-    This class models the diverging spherical wave from a single transmitting /element/ 
-    that was fired as part of an arbitrary focused transmit. It needs to know about the 
-    original transmitted wave and the original sender (the point that the wave passed 
-    through at time 0) in order to compensate for arbitrary transmit sequences. See 
+    This class models the diverging spherical wave from a single transmitting /element/
+    that was fired as part of an arbitrary focused transmit. It needs to know about the
+    original transmitted wave and the original sender (the point that the wave passed
+    through at time 0) in order to compensate for arbitrary transmit sequences. See
     :meth:`__call__` for more details.
     """
 
@@ -22,7 +21,7 @@ class REFoCUSWavefront(TransmittedWavefront):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         wave_data: WaveData,
     ) -> float:
         """Return the distance that the wave travels, starting from time 0, to when it
@@ -35,4 +34,7 @@ class REFoCUSWavefront(TransmittedWavefront):
         focusing_compensation = self.base_wavefront(
             self.base_sender, sender.position, wave_data
         )
-        return distance(sender.position, point_position) + focusing_compensation * self.compensation_scalar
+        return (
+            distance(sender.position, point_position)
+            + focusing_compensation * self.compensation_scalar
+        )

--- a/vbeam/wavefront/refocus.py
+++ b/vbeam/wavefront/refocus.py
@@ -1,4 +1,4 @@
-from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
+from vbeam.core import ProbeGeometry, TransmittedWavefront, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import distance
@@ -16,12 +16,13 @@ class REFoCUSWavefront(TransmittedWavefront):
     """
 
     base_wavefront: TransmittedWavefront
-    base_sender: ElementGeometry
+    base_sender: np.ndarray
     compensation_scalar: float = 1.0
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
@@ -33,6 +34,6 @@ class REFoCUSWavefront(TransmittedWavefront):
         transmit sequence. This compensation is the distance that the full modeled
         wavefront passed through the sending element."""
         focusing_compensation = self.base_wavefront(
-            self.base_sender, sender.position, wave_data
+            probe, self.base_sender, sender, wave_data
         )
-        return distance(sender.position, point_position) + focusing_compensation * self.compensation_scalar
+        return distance(sender, point_position) + focusing_compensation * self.compensation_scalar

--- a/vbeam/wavefront/stai.py
+++ b/vbeam/wavefront/stai.py
@@ -1,4 +1,4 @@
-from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
+from vbeam.core import ProbeGeometry, TransmittedWavefront, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import distance
@@ -8,8 +8,9 @@ from vbeam.util.geometry.v2 import distance
 class STAIWavefront(TransmittedWavefront):
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
-        return distance(sender.position, point_position)
+        return distance(probe.sender_position, point_position)

--- a/vbeam/wavefront/stai.py
+++ b/vbeam/wavefront/stai.py
@@ -1,15 +1,14 @@
+from fastmath import ArrayOrNumber
+
 from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
-from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry.v2 import distance
 
 
-@traceable_dataclass()
 class STAIWavefront(TransmittedWavefront):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         wave_data: WaveData,
     ) -> float:
         return distance(sender.position, point_position)

--- a/vbeam/wavefront/unified.py
+++ b/vbeam/wavefront/unified.py
@@ -1,32 +1,32 @@
 from dataclasses import field
 from typing import Tuple
 
-from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
+from vbeam.core import ProbeGeometry, TransmittedWavefront, WaveData
 from vbeam.fastmath import numpy as np
 from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry import Line
 from vbeam.wavefront import FocusedSphericalWavefront
 
 
-@traceable_dataclass(("array_bounds", "base_wavefront"))
+@traceable_dataclass(("base_wavefront",))
 class UnifiedWavefront(TransmittedWavefront):
     """Implementation of the unified wavefront model
 
     https://doi.org/10.1109/tmi.2015.2456982"""
 
-    array_bounds: Tuple[np.ndarray, np.ndarray]
     base_wavefront: TransmittedWavefront = field(
         default_factory=FocusedSphericalWavefront
     )
 
     def __call__(
         self,
-        sender: ElementGeometry,
+        probe: ProbeGeometry,
+        sender: np.ndarray,
         point_position: np.ndarray,
         wave_data: WaveData,
     ) -> float:
         # Set up the geometry
-        array_left, array_right = self.array_bounds
+        array_right, array_left, array_up, array_down = probe.get_tx_aperture_borders(sender=sender)
         line_left = Line.passing_through(array_left, wave_data.source)
         line_right = Line.passing_through(array_right, wave_data.source)
         midline = Line.from_anchor_and_angle(
@@ -48,8 +48,8 @@ class UnifiedWavefront(TransmittedWavefront):
         weight_B = 1 - (dist_B / total_distance)
 
         # Interpolate the distances for the intersection points of the two regions
-        R1 = self.base_wavefront(sender, A, wave_data)
-        R2 = self.base_wavefront(sender, B, wave_data)
+        R1 = self.base_wavefront(probe, sender, A, wave_data)
+        R2 = self.base_wavefront(probe, sender, B, wave_data)
         interpolated_distance = R1 * weight_A + R2 * weight_B
 
         # Calculate whether the point is in region I or III using XOR
@@ -59,6 +59,6 @@ class UnifiedWavefront(TransmittedWavefront):
         # Select the correct distance based on which region the point belongs to
         return np.where(
             is_in_focus,
-            self.base_wavefront(sender, point_position, wave_data),
+            self.base_wavefront(probe,sender, point_position, wave_data),
             interpolated_distance,
         )

--- a/vbeam/wavefront/unified.py
+++ b/vbeam/wavefront/unified.py
@@ -1,20 +1,20 @@
 from dataclasses import field
 from typing import Tuple
 
+from fastmath import ArrayOrNumber
+
 from vbeam.core import ElementGeometry, TransmittedWavefront, WaveData
 from vbeam.fastmath import numpy as np
-from vbeam.fastmath.traceable import traceable_dataclass
 from vbeam.util.geometry import Line
 from vbeam.wavefront import FocusedSphericalWavefront
 
 
-@traceable_dataclass(("array_bounds", "base_wavefront"))
 class UnifiedWavefront(TransmittedWavefront):
     """Implementation of the unified wavefront model
 
     https://doi.org/10.1109/tmi.2015.2456982"""
 
-    array_bounds: Tuple[np.ndarray, np.ndarray]
+    array_bounds: Tuple[ArrayOrNumber, ArrayOrNumber]
     base_wavefront: TransmittedWavefront = field(
         default_factory=FocusedSphericalWavefront
     )
@@ -22,7 +22,7 @@ class UnifiedWavefront(TransmittedWavefront):
     def __call__(
         self,
         sender: ElementGeometry,
-        point_position: np.ndarray,
+        point_position: ArrayOrNumber,
         wave_data: WaveData,
     ) -> float:
         # Set up the geometry

--- a/vbeam/wavefront/util.py
+++ b/vbeam/wavefront/util.py
@@ -1,6 +1,7 @@
 import math
 from typing import Optional, Sequence
 
+from fastmath import ArrayOrNumber
 from spekk import Spec
 
 from vbeam.core import (
@@ -16,7 +17,7 @@ from vbeam.util.transformations import *
 def get_transmitted_wavefront_values(
     wavefront: TransmittedWavefront,
     sender: ElementGeometry,
-    point_position: np.ndarray,
+    point_position: ArrayOrNumber,
     wave_data: WaveData,
     spec: Spec,
     dimensions: Optional[Sequence[str]] = None,
@@ -35,7 +36,7 @@ def get_transmitted_wavefront_values(
     Args:
         wavefront (TransmittedWavefront): The wavefront function to use.
         sender (ElementGeometry): The sender argument to ``wavefront``.
-        point_position (np.ndarray): The point_position argument to ``wavefront``.
+        point_position (ArrayOrNumber): The point_position argument to ``wavefront``.
         wave_data (WaveData): The wave data argument to ``wavefront``.
         spec (Spec): A spec describing the dimensions/shape of the arguments.
         dimensions (Optional[Sequence[str]]): The dimensions to keep in the returned
@@ -44,7 +45,7 @@ def get_transmitted_wavefront_values(
         jit (bool): If True, the process is JIT-compiled (if the backend supports it).
 
     Returns:
-        np.ndarray: The calculated wavefront distance values with shape corresponding
+       ArrayOrNumber: The calculated wavefront distance values with shape corresponding
         to the dimensions defined in ``dimensions``.
     """
     kwargs = {
@@ -97,7 +98,7 @@ def get_transmitted_wavefront_values(
 
 def get_reflected_wavefront_values(
     wavefront: ReflectedWavefront,
-    point_position: np.ndarray,
+    point_position: ArrayOrNumber,
     receiver: ElementGeometry,
     spec: Spec,
     dimensions: Optional[Sequence[str]] = None,
@@ -115,7 +116,7 @@ def get_reflected_wavefront_values(
 
     Args:
         wavefront (ReflectedWavefront): The wavefront function to use.
-        point_position (np.ndarray): The point_position argument to ``wavefront``.
+        point_position (ArrayOrNumber): The point_position argument to ``wavefront``.
         receiver (ElementGeometry): The receiver argument to ``wavefront``.
         spec (Spec): A spec describing the dimensions/shape of the arguments.
         dimensions (Optional[Sequence[str]]): The dimensions to keep in the returned
@@ -124,7 +125,7 @@ def get_reflected_wavefront_values(
         jit (bool): If True, the process is JIT-compiled (if the backend supports it).
 
     Returns:
-        np.ndarray: The calculated wavefront distance values with shape corresponding
+       ArrayOrNumber: The calculated wavefront distance values with shape corresponding
         to the dimensions defined in ``dimensions``.
     """
     kwargs = {

--- a/vbeam/wavefront/util.py
+++ b/vbeam/wavefront/util.py
@@ -4,7 +4,7 @@ from typing import Optional, Sequence
 from spekk import Spec
 
 from vbeam.core import (
-    ElementGeometry,
+    ProbeGeometry,
     ReflectedWavefront,
     TransmittedWavefront,
     WaveData,
@@ -15,7 +15,8 @@ from vbeam.util.transformations import *
 
 def get_transmitted_wavefront_values(
     wavefront: TransmittedWavefront,
-    sender: ElementGeometry,
+    probe: ProbeGeometry,
+    sender: np.ndarray,
     point_position: np.ndarray,
     wave_data: WaveData,
     spec: Spec,
@@ -24,7 +25,7 @@ def get_transmitted_wavefront_values(
 ):
     """
     Calculate and return the (transmit) wavefront distance values based on the provided
-    arguments (``sender``, ``point_position``, and ``wave_data``).
+    arguments (``probe``, ``sender``, ``point_position``, and ``wave_data``).
 
     The ``dimensions`` argument determines what dimensions to keep; all others are
     summed over (except when ``dimesions`` is None where we keep all dimensions
@@ -34,7 +35,7 @@ def get_transmitted_wavefront_values(
 
     Args:
         wavefront (TransmittedWavefront): The wavefront function to use.
-        sender (ElementGeometry): The sender argument to ``wavefront``.
+        sender (np.ndarray): The sender argument to ``wavefront``.
         point_position (np.ndarray): The point_position argument to ``wavefront``.
         wave_data (WaveData): The wave data argument to ``wavefront``.
         spec (Spec): A spec describing the dimensions/shape of the arguments.
@@ -49,6 +50,7 @@ def get_transmitted_wavefront_values(
     """
     kwargs = {
         "transmitted_wavefront": wavefront,
+        "probe": probe,
         "sender": sender,
         "point_position": point_position,
         "wave_data": wave_data,
@@ -62,6 +64,7 @@ def get_transmitted_wavefront_values(
     # Define what dimensions to vmap and sum over and how
     vmap_dimensions = (
         spec["transmitted_wavefront"].dimensions
+        | spec["probe"].dimensions
         | spec["sender"].dimensions
         | spec["point_position"].dimensions
         | spec["wave_data"].dimensions
@@ -98,7 +101,7 @@ def get_transmitted_wavefront_values(
 def get_reflected_wavefront_values(
     wavefront: ReflectedWavefront,
     point_position: np.ndarray,
-    receiver: ElementGeometry,
+    receiver: np.ndarray,
     spec: Spec,
     dimensions: Optional[Sequence[str]] = None,
     jit: bool = True,
@@ -116,7 +119,7 @@ def get_reflected_wavefront_values(
     Args:
         wavefront (ReflectedWavefront): The wavefront function to use.
         point_position (np.ndarray): The point_position argument to ``wavefront``.
-        receiver (ElementGeometry): The receiver argument to ``wavefront``.
+        receiver (np.ndarray): The receiver argument to ``wavefront``.
         spec (Spec): A spec describing the dimensions/shape of the arguments.
         dimensions (Optional[Sequence[str]]): The dimensions to keep in the returned
             result. If it is an empty list, all dimensions are summed over. If it is


### PR DESCRIPTION
Add probe object that stores 
- ROC
- Aperture length on receive
- Aperture length on transmit

Apodization and wavefront functions has been updated to use this.

The probe object is added to the kernel.

ElementGeometry object is no longer needed, because the theta and phi can be calculated using the probe and element positions. The receiver and sender objects are therefore changed to be np.ndarray objects instead. 


The examples optimized_scans, plane_wave_dataset and refocus_with_speed_of_sound_map has been tested and runs as previously. 

This solves issue #28 
