### PR TITLE
[feature] Option to iteratively sum apodization to reduce RAM usage

### DIFF
--- a/vbeam/apodization/util.py
+++ b/vbeam/apodization/util.py
@@ -18,6 +18,7 @@ def get_apodization_values(
     wave_data: WaveData,
     spec: Spec,
     dimensions: Optional[Sequence[str]] = None,
+    reduce_sum_dimension: Optional[Sequence[str]] = None,
     average: bool = False,
     jit: bool = True,
 ):
@@ -70,19 +71,25 @@ def get_apodization_values(
         | spec["wave_data"].dimensions
     )
     sum_dimensions = vmap_dimensions - set(dimensions)
-    reduce_sum_dimension = spec["wave_data"].dimensions & sum_dimensions
-    if reduce_sum_dimension:
-        # Make it only one of the dimensions (doesn't matter which one)
-        reduce_sum_dimension = {reduce_sum_dimension.pop()}
-        vmap_dimensions -= reduce_sum_dimension
+    if reduce_sum_dimension is None:
+        reduce_sum_dimension = spec["wave_data"].dimensions & sum_dimensions
+        if reduce_sum_dimension:
+            # Default to iterative summation over one of the dimensions (doesn't matter which one)
+            reduce_sum_dimension = {reduce_sum_dimension.pop()}
+    reduce_sum_dimension = set(reduce_sum_dimension)
+    # Some dimensions will be iterated over instead of vmap
+    vmap_dimensions: str = vmap_dimensions - reduce_sum_dimension
+    vmap_sum_dimensions: set[str] = sum_dimensions - reduce_sum_dimension
 
     # Define how to calculate the apodization values
     calculate_apodization = compose(
         lambda apodization, *args, **kwargs: apodization(*args, **kwargs),
         *[ForAll(dim) for dim in vmap_dimensions],
-        Apply(np.sum, [Axis(dim) for dim in sum_dimensions - reduce_sum_dimension]),
+        Apply(np.sum, [Axis(dim) for dim in vmap_sum_dimensions])
+        if vmap_sum_dimensions
+        else do_nothing,
         # [*reduce_sum_dimension][0] gets the "first element" of the set
-        Reduce.Sum([*reduce_sum_dimension][0]) if reduce_sum_dimension else do_nothing,
+        *[Reduce.Sum(dim) for dim in reduce_sum_dimension],
         # Put the dimensions in the order defined by keep
         Apply(np.transpose, [Axis(dim, keep=True) for dim in dimensions]),
         # Make it run faster if `jit` is True and if the backend supports it.

--- a/vbeam/data_importers/setup.py
+++ b/vbeam/data_importers/setup.py
@@ -126,7 +126,11 @@ updating the scan instead."
     def copy(self) -> "SignalForPointSetup":
         return SignalForPointSetup(**self.data, spec=self.spec, scan=self.scan)
 
-    def get_apodization_values(self, dimensions: Sequence[str]):
+    def get_apodization_values(
+        self,
+        dimensions: Sequence[str],
+        reduce_sum_dimension: Optional[Sequence[str]] = None,
+    ):
         """Return the apodization values for the dimensions. All other relevant
         dimensions are (by default) summed over.
 
@@ -142,6 +146,7 @@ updating the scan instead."
             self.wave_data,
             self.spec,
             dimensions,
+            reduce_sum_dimension,
         )
 
     def plot_apodization(


### PR DESCRIPTION
Useful for large volumes+channels, to be able to reduce-sum over channels instead of vmap-sum.

Was getting an error:
```
spekk.transformations.base.TransformedFunctionError: RESOURCE_EXHAUSTED: Out of memory allocating 195822063360 bytes.
TransformedFunction(
  <compose(
    get_apodization_values.<locals>.<lambda>,
    ForAll('receivers'),
    ForAll('points'),
    Apply(JaxBackend.sum, [Axis("receivers")]),
    Reduce("transmits", <built-in function add>, None),
    Apply(JaxBackend.transpose, [Axis("points", keep=True)]),
⚠   Wrap(JaxBackend.jit),
⚠     ↳ This step raised XlaRuntimeError('RESOURCE_EXHAUSTED: Out of memory allocating 195822063360 bytes.')
  )>
)
```

(This is a large BMode volume)

So was hoping to be able to pass in `reduce_sum_dimensions=["transmits", "receivers"]` to work around this