### PR TITLE
[fix] polar-cartesian

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ readme = "README.md"
 requires-python = ">=3.9"
 version = "1.0.8"
 
+[project.optional-dependencies]
+jax = ["jax>=0.4.1"]
+
 [project.urls]
 "Homepage" = "https://github.com/magnusdk/vbeam/"
 "Documentation" = "https://vbeam.readthedocs.io/en/latest/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ description = "vbeam: a fast and differentiable beamformer"
 name = "vbeam"
 readme = "README.md"
 
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 version = "1.0.8"
 
 [project.urls]

--- a/tests/util/test_coordinate_systems.py
+++ b/tests/util/test_coordinate_systems.py
@@ -1,6 +1,6 @@
 from typing import Callable
 
-from numpy import allclose, random
+from numpy import testing, random
 from vbeam.fastmath import Backend
 from vbeam.util.coordinate_systems import as_cartesian, as_polar
 
@@ -15,7 +15,11 @@ def test_inverse_conversions(np: Backend, jit_able: Callable[[Callable], Callabl
     # Test cases: origin, unit vector, and random points
     test_points = np.array(
         [
-            [0.0, 0.0, 0.0],  # origin
+            [
+                1e-6,
+                1e-6,
+                0.0,
+            ],  # near origin, except that theta/phi are not defined for x=y=z=0
             [1.0, 0.0, 0.0],  # unit vector
             [2.0, np.pi / 4, 1.0],
             [3.0, np.pi / 2, -1.0],
@@ -23,5 +27,9 @@ def test_inverse_conversions(np: Backend, jit_able: Callable[[Callable], Callabl
         ]
     )
 
-    assert allclose(pol2cart2pol(test_points), test_points)
-    assert allclose(cart2pol2cart(test_points), test_points)
+    testing.assert_allclose(
+        pol2cart2pol(test_points), test_points, rtol=1e-4, atol=1e-6
+    )
+    testing.assert_allclose(
+        cart2pol2cart(test_points), test_points, rtol=1e-4, atol=1e-6
+    )

--- a/tests/util/test_coordinate_systems.py
+++ b/tests/util/test_coordinate_systems.py
@@ -8,6 +8,20 @@ from vbeam.util.coordinate_systems import as_cartesian, as_polar
 def test_inverse_conversions(np: Backend, jit_able: Callable[[Callable], Callable]):
     pol2cart2pol = jit_able(lambda points: as_polar(as_cartesian(points)))
     cart2pol2cart = jit_able(lambda points: as_cartesian(as_polar(points)))
-    points = random.random((10, 3))
-    assert allclose(pol2cart2pol(points), points)
-    assert allclose(cart2pol2cart(points), points)
+
+    # Set random seed for reproducibility
+    random.seed(42)
+
+    # Test cases: origin, unit vector, and random points
+    test_points = np.array(
+        [
+            [0.0, 0.0, 0.0],  # origin
+            [1.0, 0.0, 0.0],  # unit vector
+            [2.0, np.pi / 4, 1.0],
+            [3.0, np.pi / 2, -1.0],
+            *random.random((6, 3)),  # random points
+        ]
+    )
+
+    assert allclose(pol2cart2pol(test_points), test_points)
+    assert allclose(cart2pol2cart(test_points), test_points)

--- a/vbeam/scan/sector_scan.py
+++ b/vbeam/scan/sector_scan.py
@@ -17,8 +17,9 @@ class SectorScan(Scan):
     apex: np.ndarray
 
     def get_points(self, flatten: bool = True) -> np.ndarray:
+        # TODO: elevations are not the same as theta
         polar_axis = self.elevations if self.is_3d else np.array([0.0])
-        points = grid(self.azimuths, polar_axis, self.depths, shape=(*self.shape, 3))
+        points = grid(self.depths, polar_axis, self.azimuths, shape=(*self.shape, 3))
         points = as_cartesian(points)
         # Ensure that points and apex are broadcastable
         apex = (


### PR DESCRIPTION
Making a fix for `pytest tests/util/test_coordinate_systems.py`, which was failing because one of the angles wasn't yet implemented for `as_polar`.

@alexrockhill and I were trying to figure out which coordinate convention should be used here though. Proper https://en.wikipedia.org/wiki/Spherical_coordinate_system does not seem to match the common convention in ultrasound, as shown by the difference between:

![image](https://github.com/user-attachments/assets/866f66a6-4943-4f65-8afa-6196730f9e29)

and:

https://github.com/magnusdk/vbeam/blob/0da5675/vbeam/wavefront/plane.py#L15-L21

But I couldn't find a good, specific reference for the conversion between spherical coordinates (polar/azimuth) and ultrasound angles (azimuth/elevation).

Do you have a good reference & an idea of which should be used in `vbeam`?