### PR TITLE
Fix function argument calling order

### DIFF
--- a/vbeam/apodization/plotting.py
+++ b/vbeam/apodization/plotting.py
@@ -43,16 +43,16 @@ def plot_apodization(
 
     # Calculate apodization values
     vals = get_apodization_values(
-        apodization,
-        sender,
-        point_position,
-        receiver,
-        wave_data,
-        spec,
+        apodization=apodization,
+        sender=sender,
+        point_position=point_position,
+        receiver=receiver,
+        wave_data=wave_data,
+        spec=spec,
         # We want to keep the dimensions of point_position
-        spec["point_position"].tree,
-        average_overlap,
-        jit,
+        dimensions=spec["point_position"].tree,
+        average=average_overlap,
+        jit=jit,
     )
     if postprocess is not None:
         vals = postprocess(vals)


### PR DESCRIPTION
Was trying to run the `docs/tutorials/visualizing_apodization_and_delays.ipynb` notebook and was getting an odd type error, traced it down to a mismatch in argument order:

<img width="437" alt="image" src="https://github.com/user-attachments/assets/0b9ec977-728b-4514-bad1-dfb9a04b9a30" />

(i.e. last 2 arguments don't match up)

This PR fixes the argument ordering by specifying the argument names.