### PR TITLE
fix: use size= kwarg for LinearCoordinate in SectorScanConverter

### DIFF
--- a/vbeam/scan_converters/scan_convert.py
+++ b/vbeam/scan_converters/scan_convert.py
@@ -87,7 +87,7 @@ class SectorScanConverter(ScanConverter):
                 beamspace_coordinates[key] = LinearCoordinate(
                     start=beamspace_coordinates[key][0], 
                     stop=beamspace_coordinates[key][-1], 
-                    num=len(beamspace_coordinates[key])
+                    size=len(beamspace_coordinates[key])
                 )
             else:
                 raise ValueError(


### PR DESCRIPTION
SectorScanConverter.scan_convert passes `num=` to LinearCoordinate, but the class declares only `start`, `stop`, `size` — so any `sampling_types` using LinearCoordinate raises `TypeError: __init__() got an unexpected keyword argument 'num'`. Renaming `num=` to `size=`.
